### PR TITLE
Update module path

### DIFF
--- a/asymmetric.go
+++ b/asymmetric.go
@@ -29,8 +29,8 @@ import (
 	"fmt"
 	"math/big"
 
-	josecipher "github.com/square/go-jose/v3/cipher"
-	"github.com/square/go-jose/v3/json"
+	josecipher "github.com/go-jose/go-jose/v3/cipher"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 // A generic RSA-based encrypter/verifier

--- a/crypter.go
+++ b/crypter.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 // Encrypter represents an encrypter which produces an encrypted JWE object.

--- a/cryptosigner/cryptosigner.go
+++ b/cryptosigner/cryptosigner.go
@@ -29,7 +29,7 @@ import (
 	"io"
 	"math/big"
 
-	"github.com/square/go-jose/v3"
+	"github.com/go-jose/go-jose/v3"
 )
 
 // Opaque creates an OpaqueSigner from a "crypto".Signer

--- a/cryptosigner/cryptosigner_test.go
+++ b/cryptosigner/cryptosigner_test.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/square/go-jose/v3"
+	"github.com/go-jose/go-jose/v3"
 )
 
 func TestRoundtripsJWSCryptoSigner(t *testing.T) {

--- a/encoding.go
+++ b/encoding.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 // Helper function to serialize known-good objects.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/square/go-jose/v3
+module github.com/go-jose/go-jose/v3
 
 go 1.12
 

--- a/jose-util/crypto.go
+++ b/jose-util/crypto.go
@@ -17,7 +17,7 @@
 package main
 
 import (
-	jose "github.com/square/go-jose/v3"
+	jose "github.com/go-jose/go-jose/v3"
 	"github.com/square/go-jose/jose-util/generator"
 )
 

--- a/jose-util/format.go
+++ b/jose-util/format.go
@@ -16,7 +16,7 @@
 
 package main
 
-import jose "github.com/square/go-jose/v3"
+import jose "github.com/go-jose/go-jose/v3"
 
 func expand() {
 	input := string(readInput(*inFile))

--- a/jose-util/generate.go
+++ b/jose-util/generate.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/square/go-jose/v3"
+	"github.com/go-jose/go-jose/v3"
 	"github.com/square/go-jose/jose-util/generator"
 )
 

--- a/jose-util/generator/generate.go
+++ b/jose-util/generator/generate.go
@@ -26,7 +26,7 @@ import (
 	"errors"
 	"fmt"
 
-	jose "github.com/square/go-jose/v3"
+	jose "github.com/go-jose/go-jose/v3"
 )
 
 // NewSigningKey generates a keypair for corresponding SignatureAlgorithm.

--- a/jose-util/generator/utils.go
+++ b/jose-util/generator/utils.go
@@ -21,7 +21,7 @@ import (
 	"encoding/pem"
 	"errors"
 
-	jose "github.com/square/go-jose/v3"
+	jose "github.com/go-jose/go-jose/v3"
 )
 
 func LoadJSONWebKey(json []byte, pub bool) (*jose.JSONWebKey, error) {

--- a/jose-util/main.go
+++ b/jose-util/main.go
@@ -25,7 +25,7 @@ import (
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
-	jose "github.com/square/go-jose/v3"
+	jose "github.com/go-jose/go-jose/v3"
 	generator "github.com/square/go-jose/jose-util/generator"
 )
 

--- a/jwe.go
+++ b/jwe.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 // rawJSONWebEncryption represents a raw JWE JSON object. Used for parsing/serializing.

--- a/jwk.go
+++ b/jwk.go
@@ -35,7 +35,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 // rawJSONWebKey represents a public or private key in JWK format, used for parsing/serializing.

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -32,7 +32,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"

--- a/jws.go
+++ b/jws.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 // rawJSONWebSignature represents a raw JWS JSON object. Used for parsing/serializing.

--- a/jwt/builder.go
+++ b/jwt/builder.go
@@ -21,9 +21,9 @@ import (
 	"bytes"
 	"reflect"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 
-	"github.com/square/go-jose/v3"
+	"github.com/go-jose/go-jose/v3"
 )
 
 // Builder is a utility for making JSON Web Tokens. Calls can be chained, and

--- a/jwt/builder_test.go
+++ b/jwt/builder_test.go
@@ -33,8 +33,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/square/go-jose/v3"
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 type testClaims struct {

--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 // Claims represents public claim values (as specified in RFC 7519).

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -26,8 +26,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 
-	"github.com/square/go-jose/v3"
-	"github.com/square/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 )
 
 var sharedKey = []byte("secret")

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"strings"
 
-	jose "github.com/square/go-jose/v3"
-	"github.com/square/go-jose/v3/json"
+	jose "github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 // JSONWebToken represents a JSON Web Token (as specified in RFC7519).

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	jose "github.com/square/go-jose/v3"
+	jose "github.com/go-jose/go-jose/v3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/shared.go
+++ b/shared.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 // KeyAlgorithm represents a key management algorithm.

--- a/signing.go
+++ b/signing.go
@@ -25,7 +25,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 // NonceSource represents a source of random nonces to go into JWS objects

--- a/signing_test.go
+++ b/signing_test.go
@@ -26,7 +26,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/square/go-jose/v3/json"
+	"github.com/go-jose/go-jose/v3/json"
 )
 
 type staticNonceSource string

--- a/symmetric.go
+++ b/symmetric.go
@@ -32,7 +32,7 @@ import (
 
 	"golang.org/x/crypto/pbkdf2"
 
-	josecipher "github.com/square/go-jose/v3/cipher"
+	josecipher "github.com/go-jose/go-jose/v3/cipher"
 )
 
 // RandReader is a cryptographically secure random number generator (stubbed out in tests).


### PR DESCRIPTION
Avoids an error when importing go-jose/go-jose/v3:
```
module declares its path as: github.com/square/go-jose/v3
        but was required as: github.com/go-jose/go-jose/v3
```

Related to https://github.com/square/go-jose/pull/334