### PR TITLE
RFC: Support parsing without payload

### DIFF
--- a/jws.go
+++ b/jws.go
@@ -150,12 +150,13 @@ func parseSignedFull(input string) (*JSONWebSignature, error) {
 
 // sanitized produces a cleaned-up JWS object from the raw JSON.
 func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
-	if parsed.Payload == nil {
-		return nil, fmt.Errorf("go-jose/go-jose: missing payload in JWS message")
+	var parsedPayload []byte
+	if parsed.Payload != nil {
+		parsedPayload = parsed.Payload.bytes()
 	}
 
 	obj := &JSONWebSignature{
-		payload:    parsed.Payload.bytes(),
+		payload:    parsedPayload,
 		Signatures: make([]Signature, len(parsed.Signatures)),
 	}
 


### PR DESCRIPTION
Hi Square,

As promissed this is a rebase as requestd in https://github.com/square/go-jose/pull/358 ....

According to JWS spec one can produce payload-detached serializations in compact and JSON format, but jose currently does not allow me to parse a JSON document that does not have payload included.... In our scenario we will need the protected info before validation and having this would be convenient ....

asac
p.s. Note: I realize that tests are failing, but wanted to discuss approach first ....