### PR TITLE
Fix allow multiple audiences

### DIFF
--- a/jwt/validation.go
+++ b/jwt/validation.go
@@ -87,10 +87,15 @@ func (c Claims) ValidateWithLeeway(e Expected, leeway time.Duration) error {
 	}
 
 	if len(e.Audience) != 0 {
+		flag := false
 		for _, v := range e.Audience {
-			if !c.Audience.Contains(v) {
-				return ErrInvalidAudience
+			if c.Audience.Contains(v) {
+				flag = true
+				break
 			}
+		}
+		if !flag {
+			return ErrInvalidAudience
 		}
 	}
 

--- a/jwt/validation_test.go
+++ b/jwt/validation_test.go
@@ -44,6 +44,17 @@ func TestFieldsMatch(t *testing.T) {
 		assert.NoError(t, c.Validate(v))
 	}
 
+	claimsWithSingleAudience := Claims{
+		Issuer:   "issuer",
+		Subject:  "subject",
+		Audience: []string{"a1"},
+		ID:       "42",
+	}
+
+	for _, v := range valid {
+		assert.NoError(t, claimsWithSingleAudience.Validate(v))
+	}
+
 	invalid := []struct {
 		Expected Expected
 		Error    error


### PR DESCRIPTION
Original issue is https://github.com/square/go-jose/issues/286
And PR for v2 is https://github.com/square/go-jose/pull/369

This PR allows multiple audiences.

Test result is below
```
$ go test ./jwt
ok      github.com/go-jose/go-jose/v3/jwt

```