### PR TITLE
add fallback to std URLEncoding for JWKs

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -249,6 +249,13 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 	// x5t parameters are base64url-encoded SHA thumbprints
 	// See RFC 7517, Section 4.8, https://tools.ietf.org/html/rfc7517#section-4.8
 	x5tSHA1bytes, err := base64.RawURLEncoding.DecodeString(raw.X5tSHA1)
+
+	// we might get base64 encoded parameters that include padding
+	// this is not supported by RawURLEncoding, so as a backup, let's try to decode with URL encoding
+	if err != nil {
+		x5tSHA1bytes, err = base64.URLEncoding.DecodeString(raw.X5tSHA1)
+	}
+
 	if err != nil {
 		return errors.New("go-jose/go-jose: invalid JWK, x5t header has invalid encoding")
 	}
@@ -269,6 +276,13 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 	k.CertificateThumbprintSHA1 = x5tSHA1bytes
 
 	x5tSHA256bytes, err := base64.RawURLEncoding.DecodeString(raw.X5tSHA256)
+
+	// we might get base64 encoded parameters that include padding
+	// this is not supported by RawURLEncoding, so as a backup, let's try to decode with URL encoding
+	if err != nil {
+		x5tSHA256bytes, err = base64.URLEncoding.DecodeString(raw.X5tSHA256)
+	}
+
 	if err != nil {
 		return errors.New("go-jose/go-jose: invalid JWK, x5t#S256 header has invalid encoding")
 	}

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -1098,3 +1098,19 @@ func TestJWKPaddingY(t *testing.T) {
 		t.Errorf("Expected key to be invalid, but it was valid.")
 	}
 }
+
+func TestPaddedKey(t *testing.T) {
+	key := `{
+      "kty": "RSA",
+      "e": "AQAB",
+      "x5t": "wCAFGcBT8CeA4U2mYa4z3xg0-Zw=",
+      "kid": "SIGNING_KEY",
+      "x5c": [
+        "MIIDQzCCAiugAwIBAgIGAU+7bWHIMA0GCSqGSIb3DQEBCwUAMFExGzAZBgNVBAoTEk9yYWNsZSBDb3Jwb3JhdGlvbjEhMB8GA1UECxMYaWRlbnRpdHkub3JhY2xlY2xvdWQuY29tMQ8wDQYDVQQDEwZHbG9iYWwwHhcNMTUwOTExMDgwMjMxWhcNMjUwOTExMDgwMjMxWjBRMRswGQYDVQQKExJPcmFjbGUgQ29ycG9yYXRpb24xITAfBgNVBAsTGGlkZW50aXR5Lm9yYWNsZWNsb3VkLmNvbTEPMA0GA1UEAxMGR2xvYmFsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxWVFlx+E925RYQjPnKpKtHLqUonJMI1/xyM1f4Orly9RzpcaXX7ajEkgMAzffL3rsvBQkPLmO0vHIHs4KNdWoVUmbLZerjDdfLZQl3FZuXcZKXtzVOLyBVt2SNp/k23VgyGN7+8tiAJWC9SFIPBdWD8U2dxqM9izSEn9pvoMyR5iyaEoZepazJQPLysrF23g1/gI8Bo2EUAHdO5atfGfT2YQbZPSOBWiq09QYwMRBuI0Ye0TI3GwYs1x3/2LoporOj+fkYCl4ki4JK2ifwk+TA5o29cdNSuSoA7rTZL3u+dNw0c6OPxvnW6LtCn4RpieZTh7W2sYLg8ozBwd3PHNTwIDAQABoyEwHzAdBgNVHQ4EFgQUi9Fzo9g57klDG3Kv0nK+8IhbtrIwDQYJKoZIhvcNAQELBQADggEBAKx9sZvbGiQnbO/BfgdlXwloqwjZHT3Byr91Pqp0zXrdg/QaUMIOiJQ8A85d5ptccpgNrYzIukSdFUzRP0kugyNzdFXBZ9/muhSkiFBdfBBdEwqXprdZBHcwWng9t2iww4tvzVhw06ZcIYyGUo8/e8erXmiOt9WeFhi7utQg+gyKw01RvaP73ApCpMuQjxTh7QgQNh02Xo+1QStYLFGcv+ZqHhTZwqOndZiQ68t7JcbGaZmNMxKwR4Z1go+RZ+4Ffa8d9rH1OiXWNB6ukGawQdcfZWNlUWcA7ntRSCfKP5UeDcNpHBDCVZSTvnpAEB42jiTuRuWfuA5Lq0rTDxapmzI="
+      ],
+      "alg": "RS256",
+      "n": "xWVFlx-E925RYQjPnKpKtHLqUonJMI1_xyM1f4Orly9RzpcaXX7ajEkgMAzffL3rsvBQkPLmO0vHIHs4KNdWoVUmbLZerjDdfLZQl3FZuXcZKXtzVOLyBVt2SNp_k23VgyGN7-8tiAJWC9SFIPBdWD8U2dxqM9izSEn9pvoMyR5iyaEoZepazJQPLysrF23g1_gI8Bo2EUAHdO5atfGfT2YQbZPSOBWiq09QYwMRBuI0Ye0TI3GwYs1x3_2LoporOj-fkYCl4ki4JK2ifwk-TA5o29cdNSuSoA7rTZL3u-dNw0c6OPxvnW6LtCn4RpieZTh7W2sYLg8ozBwd3PHNTw"
+    }`
+	var jwk JSONWebKey
+	require.NoError(t, jwk.UnmarshalJSON([]byte(key)))
+}


### PR DESCRIPTION
duplicate of [square/go-jose #375](https://github.com/square/go-jose/pull/375) due to hint in the conversation on that one.

In case RawURLEndocing fails while decoing JWKs, try if falling back to Standard URLEncoding can decode - which may be the case i.e with padded JWKs

The x5t and x5tSHA1 headers are defined to be base64URL encoded by RFC 7515, no words of with padding or not. Further RFC 4648 is saying:
```
[3.2](https://www.rfc-editor.org/rfc/rfc4648#section-3.2).  Padding of Encoded Data

   In some circumstances, the use of padding ("=") in base-encoded data
   is not required or used.  In the general case, when assumptions about
   the size of transported data cannot be made, padding is required to
   yield correct decoded data.

   Implementations MUST include appropriate pad characters at the end of
   encoded data unless the specification referring to this document
   explicitly states otherwise.
[...]
```
Thus, depending on the implementation - and in my experience, this is often seen with Java based implementations as the common Java Base64 libraries are doing that by default - you might get padding that in the currently released implementation will break deserialization of the keys. As described in the linked issue, for me this is exactly the case with Oracle Access Manager 12 at the moment. Applications that are using go-jose 2.5.0 and above are not functional with that environment.

fixes [square/go-jose #373](https://github.com/square/go-jose/issues/373)