### PR TITLE
DecryptMulti: handle decompression error

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -496,9 +496,12 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 	// The "zip" header parameter may only be present in the protected header.
 	if comp := obj.protected.getCompression(); comp != "" {
 		plaintext, err = decompress(comp, plaintext)
+		if err != nil {
+			return nil, fmt.Errorf("go-jose/go-jose: failed to decompress plaintext: %v", err)
+		}
 	}
 
-	return plaintext, err
+	return plaintext, nil
 }
 
 // DecryptMulti decrypts and validates the object and returns the plaintexts,
@@ -569,7 +572,10 @@ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Heade
 
 	// The "zip" header parameter may only be present in the protected header.
 	if comp := obj.protected.getCompression(); comp != "" {
-		plaintext, _ = decompress(comp, plaintext)
+		plaintext, err = decompress(comp, plaintext)
+		if err != nil {
+			return -1, Header{}, nil, fmt.Errorf("go-jose/go-jose: failed to decompress plaintext: %v", err)
+		}
 	}
 
 	sanitized, err := headers.sanitized()


### PR DESCRIPTION
In 7d3b437c, a lint was fixed in this function: `err` was ineffectually assigned to. However, the fix should have been to handle the error rather than to ignore it with `_`.