### PR TITLE
doc: document all interface{} parameters

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -123,13 +123,13 @@ func (eo *EncrypterOptions) WithType(typ ContentType) *EncrypterOptions {
 type Recipient struct {
 	Algorithm KeyAlgorithm
 	// Key must have one of these types:
-	//  - JSONWebKey
-	//  - *JSONWebKey
 	//  - ed25519.PublicKey
 	//  - *ecdsa.PublicKey
 	//  - *rsa.PublicKey
-	//  - Any type that satisfies the OpaqueKeyEncrypter interface
+	//  - *JSONWebKey
+	//  - JSONWebKey
 	//  - []byte (will be interpreted as a symmetric key)
+	//  - Any type that satisfies the OpaqueKeyEncrypter interface
 	//
 	// The type of Key must match the value of Algorithm.
 	Key        interface{}
@@ -427,16 +427,20 @@ func (ctx *genericEncrypter) Options() EncrypterOptions {
 // function does not support multi-recipient. If you desire multi-recipient
 // decryption use DecryptMulti instead.
 //
-// The decryptionKey argument most have one of these types:
-//   - *rsa.PrivateKey
+// The decryptionKey argument must contain a private or symmetric key
+// and must have one of these types:
 //   - *ecdsa.PrivateKey
-//   - []byte (will be interpreted as the bytes of a symmetric key)
-//   - string (will be interpreted as the bytes of a symmetric key)
+//   - *rsa.PrivateKey
 //   - *JSONWebKey
 //   - JSONWebKey
 //   - *JSONWebKeySet
 //   - JSONWebKeySet
+//   - []byte (a symmetric key)
+//   - string (a symmetric key)
 //   - Any type that satisfies the OpaqueKeyDecrypter interface.
+//
+// Note that ed25519 is only available for signatures, not encryption, so is
+// not an option here.
 func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) {
 	headers := obj.mergedHeaders(nil)
 

--- a/crypter.go
+++ b/crypter.go
@@ -128,7 +128,7 @@ type Recipient struct {
 	//  - *rsa.PublicKey
 	//  - *JSONWebKey
 	//  - JSONWebKey
-	//  - []byte (will be interpreted as a symmetric key)
+	//  - []byte (a symmetric key)
 	//  - Any type that satisfies the OpaqueKeyEncrypter interface
 	//
 	// The type of Key must match the value of Algorithm.

--- a/crypter.go
+++ b/crypter.go
@@ -76,14 +76,24 @@ type recipientKeyInfo struct {
 type EncrypterOptions struct {
 	Compression CompressionAlgorithm
 
-	// Optional map of additional keys to be inserted into the protected header
-	// of a JWS object. Some specifications which make use of JWS like to insert
-	// additional values here. All values must be JSON-serializable.
+	// Optional map of name/value pairs to be inserted into the protected
+	// header of a JWS object. Some specifications which make use of
+	// JWS require additional values here.
+	//
+	// Values will be serialized by [json.Marshal] and must be valid inputs to
+	// that function.
+	//
+	// [json.Marshal]: https://pkg.go.dev/encoding/json#Marshal
 	ExtraHeaders map[HeaderKey]interface{}
 }
 
 // WithHeader adds an arbitrary value to the ExtraHeaders map, initializing it
-// if necessary. It returns itself and so can be used in a fluent style.
+// if necessary, and returns the updated EncrypterOptions.
+//
+// The v parameter will be serialized by [json.Marshal] and must be a valid
+// input to that function.
+//
+// [json.Marshal]: https://pkg.go.dev/encoding/json#Marshal
 func (eo *EncrypterOptions) WithHeader(k HeaderKey, v interface{}) *EncrypterOptions {
 	if eo.ExtraHeaders == nil {
 		eo.ExtraHeaders = map[HeaderKey]interface{}{}
@@ -111,7 +121,17 @@ func (eo *EncrypterOptions) WithType(typ ContentType) *EncrypterOptions {
 // default of 100000 will be used for the count and a 128-bit random salt will
 // be generated.
 type Recipient struct {
-	Algorithm  KeyAlgorithm
+	Algorithm KeyAlgorithm
+	// Key must have one of these types:
+	//  - JSONWebKey
+	//  - *JSONWebKey
+	//  - ed25519.PublicKey
+	//  - *ecdsa.PublicKey
+	//  - *rsa.PublicKey
+	//  - Any type that satisfies the OpaqueKeyEncrypter interface
+	//  - []byte (will be interpreted as a symmetric key)
+	//
+	// The type of Key must match the value of Algorithm.
 	Key        interface{}
 	KeyID      string
 	PBES2Count int
@@ -403,9 +423,20 @@ func (ctx *genericEncrypter) Options() EncrypterOptions {
 	}
 }
 
-// Decrypt and validate the object and return the plaintext. Note that this
-// function does not support multi-recipient, if you desire multi-recipient
+// Decrypt and validate the object and return the plaintext. This
+// function does not support multi-recipient. If you desire multi-recipient
 // decryption use DecryptMulti instead.
+//
+// The decryptionKey argument most have one of these types:
+//   - *rsa.PrivateKey
+//   - *ecdsa.PrivateKey
+//   - []byte (will be interpreted as the bytes of a symmetric key)
+//   - string (will be interpreted as the bytes of a symmetric key)
+//   - *JSONWebKey
+//   - JSONWebKey
+//   - *JSONWebKeySet
+//   - JSONWebKeySet
+//   - Any type that satisfies the OpaqueKeyDecrypter interface.
 func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) {
 	headers := obj.mergedHeaders(nil)
 
@@ -471,6 +502,9 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 // with support for multiple recipients. It returns the index of the recipient
 // for which the decryption was successful, the merged headers for that recipient,
 // and the plaintext.
+//
+// The decryptionKey argument must have one of the types allowed for the
+// decryptionKey argument of Decrypt().
 func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Header, []byte, error) {
 	globalHeaders := obj.mergedHeaders(nil)
 

--- a/jwk.go
+++ b/jwk.go
@@ -67,9 +67,21 @@ type rawJSONWebKey struct {
 	X5tSHA256 string   `json:"x5t#S256,omitempty"`
 }
 
-// JSONWebKey represents a public or private key in JWK format.
+// JSONWebKey represents a public or private key in JWK format. It can be
+// marshaled into JSON and unmarshaled from JSON.
 type JSONWebKey struct {
-	// Cryptographic key, can be a symmetric or asymmetric key.
+	// Key is the Go in-memory representation of this key. It must have one
+	// of these types:
+	//  - ed25519.PublicKey
+	//  - ed25519.PrivateKey
+	//  - *ecdsa.PublicKey
+	//  - *ecdsa.PrivateKey
+	//  - *rsa.PublicKey
+	//  - *rsa.PrivateKey
+	//  - []byte (will be interpreted as a symmetric key)
+	//
+	// When marshaling this JSONWebKey into JSON, the "kty" header parameter
+	// will be automatically set based on the type of this field.
 	Key interface{}
 	// Key identifier, parsed from `kid` header.
 	KeyID string

--- a/jwk.go
+++ b/jwk.go
@@ -78,7 +78,7 @@ type JSONWebKey struct {
 	//  - *ecdsa.PrivateKey
 	//  - *rsa.PublicKey
 	//  - *rsa.PrivateKey
-	//  - []byte (will be interpreted as a symmetric key)
+	//  - []byte (a symmetric key)
 	//
 	// When marshaling this JSONWebKey into JSON, the "kty" header parameter
 	// will be automatically set based on the type of this field.

--- a/shared.go
+++ b/shared.go
@@ -183,8 +183,13 @@ type Header struct {
 	// Unverified certificate chain parsed from x5c header.
 	certificates []*x509.Certificate
 
-	// Any headers not recognised above get unmarshalled
-	// from JSON in a generic manner and placed in this map.
+	// At parse time, each header parameter with a name other than "kid",
+	// "jwk", "alg", "nonce", or "x5c"  will have its value passed to
+	// [json.Unmarshal] to unmarshal it into an interface value.
+	// The resulting value will be stored in this map, with the header
+	// parameter name as the key.
+	//
+	// [json.Unmarshal]: https://pkg.go.dev/encoding/json#Unmarshal
 	ExtraHeaders map[HeaderKey]interface{}
 }
 

--- a/signing.go
+++ b/signing.go
@@ -40,6 +40,15 @@ type Signer interface {
 }
 
 // SigningKey represents an algorithm/key used to sign a message.
+//
+// Key must have one of these types:
+//   - ed25519.PrivateKey
+//   - *rsa.PrivateKey
+//   - *ecdsa.PrivateKey
+//   - []byte (will be interpreted as the bytes of an HMAC key)
+//   - *JSONWebKey
+//   - JSONWebKey
+//   - Any type that satisfies the OpaqueSigner interface
 type SigningKey struct {
 	Algorithm SignatureAlgorithm
 	Key       interface{}
@@ -52,12 +61,20 @@ type SignerOptions struct {
 
 	// Optional map of additional keys to be inserted into the protected header
 	// of a JWS object. Some specifications which make use of JWS like to insert
-	// additional values here. All values must be JSON-serializable.
+	// additional values here. Values will be serialized by [json.Marshal] and
+	// must be valid inputs to that function.
+	//
+	// [json.Marshal]: https://pkg.go.dev/encoding/json#Marshal
 	ExtraHeaders map[HeaderKey]interface{}
 }
 
 // WithHeader adds an arbitrary value to the ExtraHeaders map, initializing it
-// if necessary. It returns itself and so can be used in a fluent style.
+// if necessary, and returns the updated SignerOptions.
+//
+// The v argument will be serialized by [json.Marshal] and must be a valid
+// input to that function.
+//
+// [json.Marshal]: https://pkg.go.dev/encoding/json#Marshal
 func (so *SignerOptions) WithHeader(k HeaderKey, v interface{}) *SignerOptions {
 	if so.ExtraHeaders == nil {
 		so.ExtraHeaders = map[HeaderKey]interface{}{}
@@ -321,12 +338,21 @@ func (ctx *genericSigner) Options() SignerOptions {
 }
 
 // Verify validates the signature on the object and returns the payload.
-// This function does not support multi-signature, if you desire multi-sig
+// This function does not support multi-signature. If you desire multi-signature
 // verification use VerifyMulti instead.
 //
 // Be careful when verifying signatures based on embedded JWKs inside the
 // payload header. You cannot assume that the key received in a payload is
 // trusted.
+//
+// The verificationKey argument must have one of these types:
+//   - ed25519.PublicKey
+//   - *rsa.PublicKey
+//   - *ecdsa.PublicKey
+//   - []byte (will be interpreted as the bytes of a MAC key)
+//   - *JSONWebKey
+//   - JSONWebKey
+//   - Any type that implements the OpaqueVerifier interface.
 func (obj JSONWebSignature) Verify(verificationKey interface{}) ([]byte, error) {
 	err := obj.DetachedVerify(obj.payload, verificationKey)
 	if err != nil {
@@ -346,6 +372,9 @@ func (obj JSONWebSignature) UnsafePayloadWithoutVerification() []byte {
 // most cases, you will probably want to use Verify instead. DetachedVerify
 // is only useful if you have a payload and signature that are separated from
 // each other.
+//
+// The verificationKey argument must have one of the types allowed for the
+// verificationKey argument of JSONWebSignature.Verify().
 func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey interface{}) error {
 	key := tryJWKS(verificationKey, obj.headers()...)
 	verifier, err := newVerifier(key)
@@ -388,6 +417,9 @@ func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey inter
 // returns the index of the signature that was verified, along with the signature
 // object and the payload. We return the signature and index to guarantee that
 // callers are getting the verified value.
+//
+// The verificationKey argument must have one of the types allowed for the
+// verificationKey argument of JSONWebSignature.Verify().
 func (obj JSONWebSignature) VerifyMulti(verificationKey interface{}) (int, Signature, []byte, error) {
 	idx, sig, err := obj.DetachedVerifyMulti(obj.payload, verificationKey)
 	if err != nil {
@@ -405,6 +437,9 @@ func (obj JSONWebSignature) VerifyMulti(verificationKey interface{}) (int, Signa
 // DetachedVerifyMulti is only useful if you have a payload and signature that are
 // separated from each other, and the signature can have multiple signers at the
 // same time.
+//
+// The verificationKey argument must have one of the types allowed for the
+// verificationKey argument of JSONWebSignature.Verify().
 func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey interface{}) (int, Signature, error) {
 	key := tryJWKS(verificationKey, obj.headers()...)
 	verifier, err := newVerifier(key)

--- a/signing.go
+++ b/signing.go
@@ -43,11 +43,11 @@ type Signer interface {
 //
 // Key must have one of these types:
 //   - ed25519.PrivateKey
-//   - *rsa.PrivateKey
 //   - *ecdsa.PrivateKey
-//   - []byte (will be interpreted as the bytes of an HMAC key)
+//   - *rsa.PrivateKey
 //   - *JSONWebKey
 //   - JSONWebKey
+//   - []byte (an HMAC key)
 //   - Any type that satisfies the OpaqueSigner interface
 type SigningKey struct {
 	Algorithm SignatureAlgorithm
@@ -61,8 +61,10 @@ type SignerOptions struct {
 
 	// Optional map of additional keys to be inserted into the protected header
 	// of a JWS object. Some specifications which make use of JWS like to insert
-	// additional values here. Values will be serialized by [json.Marshal] and
-	// must be valid inputs to that function.
+	// additional values here.
+	//
+	// Values will be serialized by [json.Marshal] and must be valid inputs to
+	// that function.
 	//
 	// [json.Marshal]: https://pkg.go.dev/encoding/json#Marshal
 	ExtraHeaders map[HeaderKey]interface{}
@@ -347,11 +349,11 @@ func (ctx *genericSigner) Options() SignerOptions {
 //
 // The verificationKey argument must have one of these types:
 //   - ed25519.PublicKey
-//   - *rsa.PublicKey
 //   - *ecdsa.PublicKey
-//   - []byte (will be interpreted as the bytes of a MAC key)
+//   - *rsa.PublicKey
 //   - *JSONWebKey
 //   - JSONWebKey
+//   - []byte (the bytes of an HMAC key; must have correct length)
 //   - Any type that implements the OpaqueVerifier interface.
 func (obj JSONWebSignature) Verify(verificationKey interface{}) ([]byte, error) {
 	err := obj.DetachedVerify(obj.payload, verificationKey)

--- a/signing.go
+++ b/signing.go
@@ -353,7 +353,7 @@ func (ctx *genericSigner) Options() SignerOptions {
 //   - *rsa.PublicKey
 //   - *JSONWebKey
 //   - JSONWebKey
-//   - []byte (the bytes of an HMAC key; must have correct length)
+//   - []byte (an HMAC key)
 //   - Any type that implements the OpaqueVerifier interface.
 func (obj JSONWebSignature) Verify(verificationKey interface{}) ([]byte, error) {
 	err := obj.DetachedVerify(obj.payload, verificationKey)


### PR DESCRIPTION
All places that the public API uses `interface{}` now document the allowable types.