### PR TITLE
Move type assertions for interface types into switches

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -270,9 +270,8 @@ func makeJWERecipient(alg KeyAlgorithm, encryptionKey interface{}) (recipientKey
 		recipient, err := makeJWERecipient(alg, encryptionKey.Key)
 		recipient.keyID = encryptionKey.KeyID
 		return recipient, err
-	}
-	if encrypter, ok := encryptionKey.(OpaqueKeyEncrypter); ok {
-		return newOpaqueKeyEncrypter(alg, encrypter)
+	case OpaqueKeyEncrypter:
+		return newOpaqueKeyEncrypter(alg, encryptionKey)
 	}
 	return recipientKeyInfo{}, ErrUnsupportedKeyType
 }
@@ -300,11 +299,11 @@ func newDecrypter(decryptionKey interface{}) (keyDecrypter, error) {
 		return newDecrypter(decryptionKey.Key)
 	case *JSONWebKey:
 		return newDecrypter(decryptionKey.Key)
+	case OpaqueKeyDecrypter:
+		return &opaqueKeyDecrypter{decrypter: decryptionKey}, nil
+	default:
+		return nil, ErrUnsupportedKeyType
 	}
-	if okd, ok := decryptionKey.(OpaqueKeyDecrypter); ok {
-		return &opaqueKeyDecrypter{decrypter: okd}, nil
-	}
-	return nil, ErrUnsupportedKeyType
 }
 
 // Implementation of encrypt method producing a JWE object.

--- a/signing.go
+++ b/signing.go
@@ -173,11 +173,11 @@ func newVerifier(verificationKey interface{}) (payloadVerifier, error) {
 		return newVerifier(verificationKey.Key)
 	case *JSONWebKey:
 		return newVerifier(verificationKey.Key)
+	case OpaqueVerifier:
+		return &opaqueVerifier{verifier: verificationKey}, nil
+	default:
+		return nil, ErrUnsupportedKeyType
 	}
-	if ov, ok := verificationKey.(OpaqueVerifier); ok {
-		return &opaqueVerifier{verifier: ov}, nil
-	}
-	return nil, ErrUnsupportedKeyType
 }
 
 func (ctx *genericSigner) addRecipient(alg SignatureAlgorithm, signingKey interface{}) error {
@@ -204,11 +204,11 @@ func makeJWSRecipient(alg SignatureAlgorithm, signingKey interface{}) (recipient
 		return newJWKSigner(alg, signingKey)
 	case *JSONWebKey:
 		return newJWKSigner(alg, *signingKey)
+	case OpaqueSigner:
+		return newOpaqueSigner(alg, signingKey)
+	default:
+		return recipientSigInfo{}, ErrUnsupportedKeyType
 	}
-	if signer, ok := signingKey.(OpaqueSigner); ok {
-		return newOpaqueSigner(alg, signer)
-	}
-	return recipientSigInfo{}, ErrUnsupportedKeyType
 }
 
 func newJWKSigner(alg SignatureAlgorithm, signingKey JSONWebKey) (recipientSigInfo, error) {


### PR DESCRIPTION
This makes reading the switch statements more consistent and easier to read, since all relevant types are contained within the statement.