### PR TITLE
Revert pull request #10 (multiple audiences)

### DIFF
--- a/jwt/validation.go
+++ b/jwt/validation.go
@@ -89,15 +89,10 @@ func (c Claims) ValidateWithLeeway(e Expected, leeway time.Duration) error {
 	}
 
 	if len(e.Audience) != 0 {
-		flag := false
 		for _, v := range e.Audience {
-			if c.Audience.Contains(v) {
-				flag = true
-				break
+			if !c.Audience.Contains(v) {
+				return ErrInvalidAudience
 			}
-		}
-		if !flag {
-			return ErrInvalidAudience
 		}
 	}
 

--- a/jwt/validation_test.go
+++ b/jwt/validation_test.go
@@ -44,17 +44,6 @@ func TestFieldsMatch(t *testing.T) {
 		assert.NoError(t, c.Validate(v))
 	}
 
-	claimsWithSingleAudience := Claims{
-		Issuer:   "issuer",
-		Subject:  "subject",
-		Audience: []string{"a1"},
-		ID:       "42",
-	}
-
-	for _, v := range valid {
-		assert.NoError(t, claimsWithSingleAudience.Validate(v))
-	}
-
 	invalid := []struct {
 		Expected Expected
 		Error    error


### PR DESCRIPTION
Per #23, PR #10 (unreleased) made the authorization properties of Claims.Validate more relaxed. Given that people may have been relying on those authorization properties, we shouldn't make that change without a change in API surface or a major version bump.