### PR TITLE
Merge v2.6.0 from upstream square repo

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -332,7 +332,7 @@ func (s *JSONWebKeySet) Key(kid string) []JSONWebKey {
 
 const rsaThumbprintTemplate = `{"e":"%s","kty":"RSA","n":"%s"}`
 const ecThumbprintTemplate = `{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`
-const edThumbprintTemplate = `{"crv":"%s","kty":"OKP",x":"%s"}`
+const edThumbprintTemplate = `{"crv":"%s","kty":"OKP","x":"%s"}`
 
 func ecThumbprintInput(curve elliptic.Curve, x, y *big.Int) (string, error) {
 	coordLength := curveSize(curve)

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -760,7 +760,7 @@ var cookbookJWKs = []string{
 // SHA-256 thumbprints of the above keys, hex-encoded
 var cookbookJWKThumbprints = []string{
 	"747ae2dd2003664aeeb21e4753fe7402846170a16bc8df8f23a8cf06d3cbe793",
-	"f6934029a341ddf81dceb753e91d17efe16664f40d9f4ed84bc5ea87e111f29d",
+	"90facafea9b1556698540f70c0117a22ea37bd5cf3ed3c47093c1707282b4b89",
 	"747ae2dd2003664aeeb21e4753fe7402846170a16bc8df8f23a8cf06d3cbe793",
 	"f63838e96077ad1fc01c3f8405774dedc0641f558ebb4b40dccf5f9b6d66a932",
 	"0fc478f8579325fcee0d4cbc6d9d1ce21730a6e97e435d6008fb379b0ebe47d4",


### PR DESCRIPTION
The square/go-jose repo had one commit "Fix EC thumbprint template" which existed on the v2.6.0 tag but not on the v2 branch. This means that it was missed in the recent PR which merged square's v2 branch into this repository's v2 branch. This also means that the current v2.6.0 tag in this repo points to a commit which is not on any branch in this repo.

Fix this situation by producing another merge commit which brings in the one dangling commit from the square repo.

NOTE: this change MUST be merged using the "Merge" strategy, so that the underlying "Fix EC thumbprint template" commit is left untouched, so that the existing v2.6.0 tag can continue to point at it. It MUST NOT be merged using the "Squash and Merge" nor the "Rebase" strategy.