### PR TITLE
Replace deprecated iotuil functions with io and os functions

### DIFF
--- a/jose-util/io.go
+++ b/jose-util/io.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -28,9 +27,9 @@ func readInput(path string) []byte {
 	var err error
 
 	if path != "" {
-		bytes, err = ioutil.ReadFile(path)
+		bytes, err = io.ReadFile(path)
 	} else {
-		bytes, err = ioutil.ReadAll(os.Stdin)
+		bytes, err = io.ReadAll(os.Stdin)
 	}
 
 	app.FatalIfError(err, "unable to read input")
@@ -57,7 +56,7 @@ func writeOutput(path string, data []byte) {
 	var err error
 
 	if path != "" {
-		err = ioutil.WriteFile(path, data, 0644)
+		err = os.WriteFile(path, data, 0644)
 	} else {
 		_, err = os.Stdout.Write(data)
 	}
@@ -82,7 +81,7 @@ func outputStream(path string) *os.File {
 
 // Byte contents of key file
 func keyBytes() []byte {
-	keyBytes, err := ioutil.ReadFile(*keyFile)
+	keyBytes, err := os.ReadFile(*keyFile)
 	app.FatalIfError(err, "unable to read key file")
 	return keyBytes
 }

--- a/json/bench_test.go
+++ b/json/bench_test.go
@@ -13,7 +13,7 @@ package json
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -47,7 +47,7 @@ func codeInit() {
 	if err != nil {
 		panic(err)
 	}
-	data, err := ioutil.ReadAll(gz)
+	data, err := io.ReadAll(gz)
 	if err != nil {
 		panic(err)
 	}
@@ -82,7 +82,7 @@ func BenchmarkCodeEncoder(b *testing.B) {
 		codeInit()
 		b.StartTimer()
 	}
-	enc := NewEncoder(ioutil.Discard)
+	enc := NewEncoder(io.Discard)
 	for i := 0; i < b.N; i++ {
 		if err := enc.Encode(&codeStruct); err != nil {
 			b.Fatal("Encode:", err)

--- a/json/stream_test.go
+++ b/json/stream_test.go
@@ -7,7 +7,6 @@ package json
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -102,7 +101,7 @@ func TestDecoderBuffered(t *testing.T) {
 	if m.Name != "Gopher" {
 		t.Errorf("Name = %q; want Gopher", m.Name)
 	}
-	rest, err := ioutil.ReadAll(d.Buffered())
+	rest, err := io.ReadAll(d.Buffered())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +202,7 @@ func BenchmarkEncoderEncode(b *testing.B) {
 	}
 	v := &T{"foo", "bar"}
 	for i := 0; i < b.N; i++ {
-		if err := NewEncoder(ioutil.Discard).Encode(v); err != nil {
+		if err := NewEncoder(io.Discard).Encode(v); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Per links below:
> Deprecated: As of Go 1.16, this function (ioutil.ReadAll) simply calls io.ReadAll.
> Deprecated: As of Go 1.16, this function (ioutil.ReadFile) simply calls os.ReadFile. 
> Deprecated: As of Go 1.16, this function (ioutil.WriteFile) simply calls os.WriteFile. 
> Discard is an io.Writer on which all Write calls succeed without doing anything. Deprecated: As of Go 1.16, this value (ioutil.Discard) is simply io.Discard. 

1. https://pkg.go.dev/io/ioutil#ReadAll
2. https://pkg.go.dev/io/ioutil#ReadFile
3. https://pkg.go.dev/io/ioutil#WriteFile
4. https://pkg.go.dev/io/ioutil#pkg-variables

