### PR TITLE
Add Thumbprint support for opaque signers

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -401,6 +401,8 @@ func (k *JSONWebKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 		input, err = rsaThumbprintInput(key.N, key.E)
 	case ed25519.PrivateKey:
 		input, err = edThumbprintInput(ed25519.PublicKey(key[32:]))
+	case OpaqueSigner:
+		return key.Public().Thumbprint(hash)
 	default:
 		return nil, fmt.Errorf("go-jose/go-jose: unknown key type '%s'", reflect.TypeOf(key))
 	}


### PR DESCRIPTION
### Description

This commit allows getting a thumbprint for the type OpaqueSigner. So if a key is backed by a custom signer, for example, a YubiKey or a cloud signer, we should be able to get the thumbprint for it as long as the public key is one of the supported ones.