### PR TITLE
gofmt 1.20

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -15,13 +15,11 @@
  */
 
 /*
-
 Package jose aims to provide an implementation of the Javascript Object Signing
 and Encryption set of standards. It implements encryption and signing based on
 the JSON Web Encryption and JSON Web Signature standards, with optional JSON Web
 Token support available in a sub-package. The library supports both the compact
 and JWS/JWE JSON Serialization formats, and has optional support for multiple
 recipients.
-
 */
 package jose

--- a/json/decode.go
+++ b/json/decode.go
@@ -75,14 +75,13 @@ import (
 //
 // The JSON null value unmarshals into an interface, map, pointer, or slice
 // by setting that Go value to nil. Because null is often used in JSON to mean
-// ``not present,'' unmarshaling a JSON null into any other Go type has no effect
+// “not present,” unmarshaling a JSON null into any other Go type has no effect
 // on the value and produces no error.
 //
 // When unmarshaling quoted strings, invalid UTF-8 or
 // invalid UTF-16 surrogate pairs are not treated as an error.
 // Instead, they are replaced by the Unicode replacement
 // character U+FFFD.
-//
 func Unmarshal(data []byte, v interface{}) error {
 	// Check for well-formedness.
 	// Avoids filling out half a data structure

--- a/json/encode.go
+++ b/json/encode.go
@@ -58,6 +58,7 @@ import (
 // becomes a member of the object unless
 //   - the field's tag is "-", or
 //   - the field is empty and its tag specifies the "omitempty" option.
+//
 // The empty values are false, 0, any
 // nil pointer or interface value, and any array, slice, map, or string of
 // length zero. The object's default key string is the struct field name
@@ -65,28 +66,28 @@ import (
 // the struct field's tag value is the key name, followed by an optional comma
 // and options. Examples:
 //
-//   // Field is ignored by this package.
-//   Field int `json:"-"`
+//	// Field is ignored by this package.
+//	Field int `json:"-"`
 //
-//   // Field appears in JSON as key "myName".
-//   Field int `json:"myName"`
+//	// Field appears in JSON as key "myName".
+//	Field int `json:"myName"`
 //
-//   // Field appears in JSON as key "myName" and
-//   // the field is omitted from the object if its value is empty,
-//   // as defined above.
-//   Field int `json:"myName,omitempty"`
+//	// Field appears in JSON as key "myName" and
+//	// the field is omitted from the object if its value is empty,
+//	// as defined above.
+//	Field int `json:"myName,omitempty"`
 //
-//   // Field appears in JSON as key "Field" (the default), but
-//   // the field is skipped if empty.
-//   // Note the leading comma.
-//   Field int `json:",omitempty"`
+//	// Field appears in JSON as key "Field" (the default), but
+//	// the field is skipped if empty.
+//	// Note the leading comma.
+//	Field int `json:",omitempty"`
 //
 // The "string" option signals that a field is stored as JSON inside a
 // JSON-encoded string. It applies only to fields of string, floating point,
 // integer, or boolean types. This extra level of encoding is sometimes used
 // when communicating with JavaScript programs:
 //
-//    Int64String int64 `json:",string"`
+//	Int64String int64 `json:",string"`
 //
 // The key name will be used if it's a non-empty string consisting of
 // only Unicode letters, digits, dollar signs, percent signs, hyphens,
@@ -133,7 +134,6 @@ import (
 // JSON cannot represent cyclic data structures and Marshal does not
 // handle them.  Passing cyclic structures to Marshal will result in
 // an infinite recursion.
-//
 func Marshal(v interface{}) ([]byte, error) {
 	e := &encodeState{}
 	err := e.marshal(v)

--- a/json/stream.go
+++ b/json/stream.go
@@ -240,7 +240,6 @@ var _ Unmarshaler = (*RawMessage)(nil)
 //	Number, for JSON numbers
 //	string, for JSON string literals
 //	nil, for JSON null
-//
 type Token interface{}
 
 const (

--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -119,7 +119,7 @@ func (s Audience) MarshalJSON() ([]byte, error) {
 	return json.Marshal([]string(s))
 }
 
-//Contains checks whether a given string is included in the Audience
+// Contains checks whether a given string is included in the Audience
 func (s Audience) Contains(v string) bool {
 	for _, a := range s {
 		if a == v {

--- a/jwt/doc.go
+++ b/jwt/doc.go
@@ -15,8 +15,6 @@
  */
 
 /*
-
 Package jwt provides an implementation of the JSON Web Token standard.
-
 */
 package jwt

--- a/opaque.go
+++ b/opaque.go
@@ -121,7 +121,7 @@ func (oke *opaqueKeyEncrypter) encryptKey(cek []byte, alg KeyAlgorithm) (recipie
 	return oke.encrypter.encryptKey(cek, alg)
 }
 
-//OpaqueKeyDecrypter is an interface that supports decrypting keys with an opaque key.
+// OpaqueKeyDecrypter is an interface that supports decrypting keys with an opaque key.
 type OpaqueKeyDecrypter interface {
 	DecryptKey(encryptedKey []byte, header Header) ([]byte, error)
 }


### PR DESCRIPTION
Apply `gofmt` 1.20 formatting changes.

```console
$ gofmt -l -s -w *.go json/*.go jwt/*.go
```

(no changes in other directories: `jose-util/**`, `cryptosigner`, `cipher`)