### PR TITLE
Bump golang to 1.21 GA

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         GO_VERSION:
           - "1.16.x"
-          - "1.20.x"
           - "1.21.x"
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +37,6 @@ jobs:
         GO_VERSION:
           # go1.16 does not meet the minimum requirements to run govulncheck so
           # we will skip testing against it.
-          - "1.20.x"
           - "1.21.x"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
         GO_VERSION:
           - "1.16.x"
           - "1.20.x"
-          - "1.21.0-rc.2"
+          - "1.21.x"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -39,7 +39,7 @@ jobs:
           # go1.16 does not meet the minimum requirements to run govulncheck so
           # we will skip testing against it.
           - "1.20.x"
-          - "1.21.0-rc.2"
+          - "1.21.x"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Bump golang to 1.21 GA

- test passed https://github.com/arukiidou/go-jose/pull/1