### PR TITLE
Add DetachedCompactSerialize to jwt.signedBuilder

### DIFF
--- a/jwt/builder.go
+++ b/jwt/builder.go
@@ -203,6 +203,20 @@ func (b *signedBuilder) CompactSerialize() (string, error) {
 	return sig.CompactSerialize()
 }
 
+type DetachedSerializer interface{ DetachedCompactSerialize() (string, error) }
+
+var _ DetachedSerializer = (*signedBuilder)(nil)
+
+// DetachedCompactSerialise serializes a detached token using the detached compact serialization format (compact with missing middle part).
+func (b *signedBuilder) DetachedCompactSerialize() (string, error) {
+	sig, err := b.sign()
+	if err != nil {
+		return "", err
+	}
+
+	return sig.DetachedCompactSerialize()
+}
+
 func (b *signedBuilder) FullSerialize() (string, error) {
 	sig, err := b.sign()
 	if err != nil {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -101,6 +101,24 @@ func ParseSigned(s string) (*JSONWebToken, error) {
 	}, nil
 }
 
+// ParseDetached parses detached token from JWS form.
+func ParseDetached(s string, payload []byte) (*JSONWebToken, error) {
+	sig, err := jose.ParseDetached(s, payload)
+	if err != nil {
+		return nil, err
+	}
+	headers := make([]jose.Header, len(sig.Signatures))
+	for i, signature := range sig.Signatures {
+		headers[i] = signature.Header
+	}
+
+	return &JSONWebToken{
+		payload:           sig.Verify,
+		unverifiedPayload: sig.UnsafePayloadWithoutVerification,
+		Headers:           headers,
+	}, nil
+}
+
 // ParseEncrypted parses token from JWE form.
 func ParseEncrypted(s string) (*JSONWebToken, error) {
 	enc, err := jose.ParseEncrypted(s)


### PR DESCRIPTION
To allow creating detached signed tokens.

Way easier and nicer then 
a) replicate jwt.signedBuilder functionality to allow it to call (*signedBuilder).sign().DetachedCompactSerialize()
b) hack with unsafe to get (*signedBuilder).sign().

The most hack-friendly would be exporting Sign, but maybe that's too liberating.