### PR TITLE
Add UnsafeCertificatesWithoutVerification function

### DIFF
--- a/jws_test.go
+++ b/jws_test.go
@@ -616,6 +616,11 @@ func TestJWSWithCertificateChain(t *testing.T) {
 		if !testCase.success && (len(chains) != 0 && err == nil) {
 			t.Fatalf("incorrectly verified certificate chain for test case %d (should fail)", i)
 		}
+
+		unverifiedCertificates := parsed.Signatures[0].Protected.UnsafeCertificatesWithoutVerification()
+		if testCase.success && len(unverifiedCertificates) == 0 {
+			t.Fatal("failed to get unverified certificates")
+		}
 	}
 }
 

--- a/shared.go
+++ b/shared.go
@@ -213,6 +213,15 @@ func (h Header) Certificates(opts x509.VerifyOptions) ([][]*x509.Certificate, er
 	return leaf.Verify(opts)
 }
 
+// UnsafeCertificatesWithoutVerification returns the certificate chain present
+// in the x5c header field of a message, if one was present.
+// UnsafeCertificatesWithoutVerification does not verify certificates.
+func (h Header) UnsafeCertificatesWithoutVerification() []*x509.Certificate {
+	certificates := make([]*x509.Certificate, len(h.certificates))
+	copy(certificates, h.certificates)
+	return certificates
+}
+
 func (parsed rawHeader) set(k HeaderKey, v interface{}) error {
 	b, err := json.Marshal(v)
 	if err != nil {


### PR DESCRIPTION
I need to verify certificates, based on my rules. Unfortunately, it is not possible to call `Certificates` to get `certificates` without any verification. As result, at present I have 2 not good options:
1. Using reflection to get `certificates` from `type Header`. It works, but I don't like to use reflection in production code. 
2. Parse a token one more time just to get `certificates`. It works, but requires duplicate parsing code, and spend additional CPU for parsing token/certificates.