### PR TITLE
Updated go-jose v3.0.0 to v3.0.1 in jose-util

### DIFF
--- a/jose-util/go.mod
+++ b/jose-util/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/go-jose/go-jose/v3 v3.0.0-00010101000000-000000000000
+	github.com/go-jose/go-jose/v3 v3.0.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 


### PR DESCRIPTION
Hi, I get the following error when I `go get -u jose-util`.

```bash
$ go get -u github.com/go-jose/go-jose/jose-util
go: github.com/go-jose/go-jose/jose-util@upgrade (v0.0.0-20231117013707-053c9bf3d6ce) requires github.com/go-jose/go-jose/v3@v3.0.0-00010101000000-000000000000: github.com/go-jose/go-jose/v3@v3.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```

Perhaps updating `go-jose` in `go.mod` will solve the problem, but since v3.0.1 has been released, I have updated that. 
Thank you in advance.