### PR TITLE
go.mod: bump major version to v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-jose/go-jose/v3
+module github.com/go-jose/go-jose/v4
 
 go 1.12
 


### PR DESCRIPTION
In anticipation of API-breaking changes.