### PR TITLE
jwt: accept only Compact Serialization

### DIFF
--- a/jws.go
+++ b/jws.go
@@ -75,16 +75,28 @@ type Signature struct {
 	original  *rawSignatureInfo
 }
 
-// ParseSigned parses a signed message in compact or JWS JSON Serialization format.
+// ParseSigned parses a signed message in JWS Compact or JWS JSON Serialization.
+//
+// https://datatracker.ietf.org/doc/html/rfc7515#section-7
 func ParseSigned(
 	signature string,
 	signatureAlgorithms []SignatureAlgorithm,
 ) (*JSONWebSignature, error) {
 	signature = stripWhitespace(signature)
 	if strings.HasPrefix(signature, "{") {
-		return parseSignedFull(signature, signatureAlgorithms)
+		return ParseSignedJSON(signature, signatureAlgorithms)
 	}
 
+	return parseSignedCompact(signature, nil, signatureAlgorithms)
+}
+
+// ParseSignedCompact parses a message in JWS Compact Serialization.
+//
+// https://datatracker.ietf.org/doc/html/rfc7515#section-7.1
+func ParseSignedCompact(
+	signature string,
+	signatureAlgorithms []SignatureAlgorithm,
+) (*JSONWebSignature, error) {
 	return parseSignedCompact(signature, nil, signatureAlgorithms)
 }
 
@@ -144,8 +156,10 @@ func (obj JSONWebSignature) computeAuthData(payload []byte, signature *Signature
 	return authData.Bytes(), nil
 }
 
-// parseSignedFull parses a message in full format.
-func parseSignedFull(
+// ParseSignedJSON parses a message in JWS JSON Serialization.
+//
+// https://datatracker.ietf.org/doc/html/rfc7515#section-7.2
+func ParseSignedJSON(
 	input string,
 	signatureAlgorithms []SignatureAlgorithm,
 ) (*JSONWebSignature, error) {

--- a/jwt/builder.go
+++ b/jwt/builder.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Builder is a utility for making JSON Web Tokens. Calls can be chained, and
-// errors are accumulated until the final call to CompactSerialize/FullSerialize.
+// errors are accumulated until the final call to Serialize.
 type Builder interface {
 	// Claims encodes claims into JWE/JWS form. Multiple calls will merge claims
 	// into single JSON object. If you are passing private claims, make sure to set
@@ -36,15 +36,13 @@ type Builder interface {
 	Claims(i interface{}) Builder
 	// Token builds a JSONWebToken from provided data.
 	Token() (*JSONWebToken, error)
-	// FullSerialize serializes a token using the JWS/JWE JSON Serialization format.
-	FullSerialize() (string, error)
-	// CompactSerialize serializes a token using the compact serialization format.
-	CompactSerialize() (string, error)
+	// Serialize serializes a token.
+	Serialize() (string, error)
 }
 
 // NestedBuilder is a utility for making Signed-Then-Encrypted JSON Web Tokens.
 // Calls can be chained, and errors are accumulated until final call to
-// CompactSerialize/FullSerialize.
+// Serialize.
 type NestedBuilder interface {
 	// Claims encodes claims into JWE/JWS form. Multiple calls will merge claims
 	// into single JSON object. If you are passing private claims, make sure to set
@@ -53,10 +51,8 @@ type NestedBuilder interface {
 	Claims(i interface{}) NestedBuilder
 	// Token builds a NestedJSONWebToken from provided data.
 	Token() (*NestedJSONWebToken, error)
-	// FullSerialize serializes a token using the JSON Serialization format.
-	FullSerialize() (string, error)
-	// CompactSerialize serializes a token using the compact serialization format.
-	CompactSerialize() (string, error)
+	// Serialize serializes a token.
+	Serialize() (string, error)
 }
 
 type builder struct {
@@ -194,22 +190,13 @@ func (b *signedBuilder) Token() (*JSONWebToken, error) {
 	return b.builder.token(sig.Verify, h)
 }
 
-func (b *signedBuilder) CompactSerialize() (string, error) {
+func (b *signedBuilder) Serialize() (string, error) {
 	sig, err := b.sign()
 	if err != nil {
 		return "", err
 	}
 
 	return sig.CompactSerialize()
-}
-
-func (b *signedBuilder) FullSerialize() (string, error) {
-	sig, err := b.sign()
-	if err != nil {
-		return "", err
-	}
-
-	return sig.FullSerialize(), nil
 }
 
 func (b *signedBuilder) sign() (*jose.JSONWebSignature, error) {
@@ -232,22 +219,13 @@ func (b *encryptedBuilder) Claims(i interface{}) Builder {
 	}
 }
 
-func (b *encryptedBuilder) CompactSerialize() (string, error) {
+func (b *encryptedBuilder) Serialize() (string, error) {
 	enc, err := b.encrypt()
 	if err != nil {
 		return "", err
 	}
 
 	return enc.CompactSerialize()
-}
-
-func (b *encryptedBuilder) FullSerialize() (string, error) {
-	enc, err := b.encrypt()
-	if err != nil {
-		return "", err
-	}
-
-	return enc.FullSerialize(), nil
 }
 
 func (b *encryptedBuilder) Token() (*JSONWebToken, error) {
@@ -295,7 +273,7 @@ func (b *nestedBuilder) Token() (*NestedJSONWebToken, error) {
 	}, nil
 }
 
-func (b *nestedBuilder) CompactSerialize() (string, error) {
+func (b *nestedBuilder) Serialize() (string, error) {
 	enc, err := b.signAndEncrypt()
 	if err != nil {
 		return "", err

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -147,7 +147,7 @@ func ExampleSigned() {
 		NotBefore: jwt.NewNumericDate(time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)),
 		Audience:  jwt.Audience{"leela", "fry"},
 	}
-	raw, err := jwt.Signed(sig).Claims(cl).CompactSerialize()
+	raw, err := jwt.Signed(sig).Claims(cl).Serialize()
 	if err != nil {
 		panic(err)
 	}
@@ -179,7 +179,7 @@ func ExampleSigned_privateClaims() {
 		"custom claim value",
 	}
 
-	raw, err := jwt.Signed(sig).Claims(cl).Claims(privateCl).CompactSerialize()
+	raw, err := jwt.Signed(sig).Claims(cl).Claims(privateCl).Serialize()
 	if err != nil {
 		panic(err)
 	}
@@ -202,7 +202,7 @@ func ExampleEncrypted() {
 		Subject: "subject",
 		Issuer:  "issuer",
 	}
-	raw, err := jwt.Encrypted(enc).Claims(cl).CompactSerialize()
+	raw, err := jwt.Encrypted(enc).Claims(cl).Serialize()
 	if err != nil {
 		panic(err)
 	}
@@ -226,7 +226,7 @@ func ExampleSignedAndEncrypted() {
 		Subject: "subject",
 		Issuer:  "issuer",
 	}
-	raw, err := jwt.SignedAndEncrypted(rsaSigner, enc).Claims(cl).CompactSerialize()
+	raw, err := jwt.SignedAndEncrypted(rsaSigner, enc).Claims(cl).Serialize()
 	if err != nil {
 		panic(err)
 	}
@@ -244,7 +244,7 @@ func ExampleSigned_multipleClaims() {
 	}{
 		[]string{"foo", "bar"},
 	}
-	raw, err := jwt.Signed(signer).Claims(c).Claims(c2).CompactSerialize()
+	raw, err := jwt.Signed(signer).Claims(c).Claims(c2).Serialize()
 	if err != nil {
 		panic(err)
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -87,7 +87,7 @@ func (t *NestedJSONWebToken) Decrypt(decryptionKey interface{}) (*JSONWebToken, 
 
 // ParseSigned parses token from JWS form.
 func ParseSigned(s string, signatureAlgorithms []jose.SignatureAlgorithm) (*JSONWebToken, error) {
-	sig, err := jose.ParseSigned(s, signatureAlgorithms)
+	sig, err := jose.ParseSignedCompact(s, signatureAlgorithms)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func ParseEncrypted(s string,
 	keyAlgorithms []jose.KeyAlgorithm,
 	contentEncryption []jose.ContentEncryption,
 ) (*JSONWebToken, error) {
-	enc, err := jose.ParseEncrypted(s, keyAlgorithms, contentEncryption)
+	enc, err := jose.ParseEncryptedCompact(s, keyAlgorithms, contentEncryption)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func ParseSignedAndEncrypted(s string,
 	contentEncryption []jose.ContentEncryption,
 	signatureAlgorithms []jose.SignatureAlgorithm,
 ) (*NestedJSONWebToken, error) {
-	enc, err := jose.ParseEncrypted(s, encryptionKeyAlgorithms, contentEncryption)
+	enc, err := jose.ParseEncryptedCompact(s, encryptionKeyAlgorithms, contentEncryption)
 	if err != nil {
 		return nil, err
 	}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -203,7 +203,7 @@ func TestTamperedJWT(t *testing.T) {
 		Issuer:  "bar",
 	}
 
-	raw, _ := Encrypted(sig).Claims(cl).CompactSerialize()
+	raw, _ := Encrypted(sig).Claims(cl).Serialize()
 
 	// Modify with valid base64 junk
 	r := strings.Split(raw, ".")


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7519#section-1

> JWTs are always represented using the JWS Compact Serialization
> or the JWE Compact Serialization.

To do this, expose specific methods for different serializations in the top level jose package:

 - ParseSignedCompact
 - ParseSignedJSON
 - ParseEncryptedCompact
 - ParseEncryptedJSON

Also remove the CompactSerialize / FullSerialize distinction in the JWT builder objects. There's just Serialize because there's only one valid serialization.

Inspired by the "polyglot token" attack in
https://i.blackhat.com/BH-US-23/Presentations/US-23-Tervoort-Three-New-Attacks-Against-JSON-Web-Tokens-whitepaper.pdf