### PR TITLE
jwt: use AnyAudience matching

### DIFF
--- a/jwt/validation_test.go
+++ b/jwt/validation_test.go
@@ -35,13 +35,15 @@ func TestFieldsMatch(t *testing.T) {
 	valid := []Expected{
 		{Issuer: "issuer"},
 		{Subject: "subject"},
-		{Audience: Audience{"a1", "a2"}},
-		{Audience: Audience{"a2", "a1"}},
+		{AnyAudience: Audience{"a1", "a2"}},
+		{AnyAudience: Audience{"a2", "a1"}},
+		{AnyAudience: Audience{"a1"}},
+		{AnyAudience: Audience{"a2"}},
 		{ID: "42"},
 	}
 
 	for _, v := range valid {
-		assert.NoError(t, c.Validate(v))
+		assert.NoError(t, c.Validate(v), "expected %#v to match %#v", c, v)
 	}
 
 	invalid := []struct {
@@ -50,7 +52,8 @@ func TestFieldsMatch(t *testing.T) {
 	}{
 		{Expected{Issuer: "invalid-issuer"}, ErrInvalidIssuer},
 		{Expected{Subject: "invalid-subject"}, ErrInvalidSubject},
-		{Expected{Audience: Audience{"invalid-audience"}}, ErrInvalidAudience},
+		{Expected{AnyAudience: Audience{"invalid-audience"}}, ErrInvalidAudience},
+		{Expected{AnyAudience: Audience{"invalid-audience", "invalid2"}}, ErrInvalidAudience},
 		{Expected{ID: "invalid-id"}, ErrInvalidID},
 	}
 


### PR DESCRIPTION
Previously, the `Expected.Audience` field meant "all of these audiences must be present in the token." But that doesn't really make sense with the spec:

https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3

Instead, rename the field to `AnyAudience` and changes its semantics to mean "there must be an intersection between this set and the set of audiences in the token."

Re-land of #10 on the `main` (v4) branch. Followup of #23 and #24. cc @shnmorimoto