### PR TITLE
Enforce minimum length for HMAC keys

### DIFF
--- a/jwt/builder_test.go
+++ b/jwt/builder_test.go
@@ -395,7 +395,7 @@ func mustMakeSigner(alg jose.SignatureAlgorithm, k interface{}) jose.Signer {
 }
 
 var (
-	sharedKey           = []byte("secret")
+	sharedKey           = []byte("0102030405060708090A0B0C0D0E0F10")
 	sharedEncryptionKey = []byte("itsa16bytesecret")
 
 	testPrivRSAKey1 = mustUnmarshalRSA(`-----BEGIN PRIVATE KEY-----

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -30,20 +30,23 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 )
 
-var sharedKey = []byte("secret")
+var sharedKey = []byte("0102030405060708090A0B0C0D0E0F10")
 var sharedEncryptionKey = []byte("itsa16bytesecret")
 var signer, _ = jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: sharedKey}, &jose.SignerOptions{})
 
 func ExampleParseSigned() {
-	raw := `eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJzdWJqZWN0In0.gpHyA1B1H6X4a4Edm9wo7D3X2v3aLSDBDG2_5BzXYe0`
+	raw := `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJzdWJqZWN0In0.OFD0iVfPczqWBA_TRi1jGB5PF699eekcHt4D6qNoimc`
+
 	tok, err := jwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.HS256})
 	if err != nil {
-		panic(err)
+		fmt.Printf("parsing JWT: %s\n", err)
+		return
 	}
 
 	out := jwt.Claims{}
 	if err := tok.Claims(sharedKey, &out); err != nil {
-		panic(err)
+		fmt.Printf("validating claims: %s\n", err)
+		return
 	}
 	fmt.Printf("iss: %s, sub: %s\n", out.Issuer, out.Subject)
 	// Output: iss: issuer, sub: subject
@@ -54,12 +57,14 @@ func ExampleParseEncrypted() {
 	raw := `eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..jg45D9nmr6-8awml.z-zglLlEw9MVkYHi-Znd9bSwc-oRGbqKzf9WjXqZxno.kqji2DiZHZmh-1bLF6ARPw`
 	tok, err := jwt.ParseEncrypted(raw, []jose.KeyAlgorithm{jose.DIRECT}, []jose.ContentEncryption{jose.A128GCM})
 	if err != nil {
-		panic(err)
+		fmt.Printf("parsing JWT: %s\n", err)
+		return
 	}
 
 	out := jwt.Claims{}
 	if err := tok.Claims(key, &out); err != nil {
-		panic(err)
+		fmt.Printf("validating claims: %s\n", err)
+		return
 	}
 	fmt.Printf("iss: %s, sub: %s\n", out.Issuer, out.Subject)
 	// Output: iss: issuer, sub: subject
@@ -72,17 +77,20 @@ func ExampleParseSignedAndEncrypted() {
 		[]jose.ContentEncryption{jose.A128GCM},
 		[]jose.SignatureAlgorithm{jose.RS256})
 	if err != nil {
-		panic(err)
+		fmt.Printf("validating claims: %s\n", err)
+		return
 	}
 
 	nested, err := tok.Decrypt(sharedEncryptionKey)
 	if err != nil {
-		panic(err)
+		fmt.Printf("decrypting JWT: %s\n", err)
+		return
 	}
 
 	out := jwt.Claims{}
 	if err := nested.Claims(&rsaPrivKey.PublicKey, &out); err != nil {
-		panic(err)
+		fmt.Printf("validating claims: %s\n", err)
+		return
 	}
 
 	fmt.Printf("iss: %s, sub: %s\n", out.Issuer, out.Subject)
@@ -103,7 +111,8 @@ func ExampleClaims_Validate() {
 		Time:   time.Date(2016, 1, 1, 0, 10, 0, 0, time.UTC),
 	})
 	if err != nil {
-		panic(err)
+		fmt.Printf("validating claims: %s\n", err)
+		return
 	}
 
 	fmt.Printf("valid!")
@@ -111,15 +120,17 @@ func ExampleClaims_Validate() {
 }
 
 func ExampleClaims_Validate_withParse() {
-	raw := `eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJzdWJqZWN0In0.gpHyA1B1H6X4a4Edm9wo7D3X2v3aLSDBDG2_5BzXYe0`
+	raw := `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJzdWJqZWN0In0.OFD0iVfPczqWBA_TRi1jGB5PF699eekcHt4D6qNoimc`
 	tok, err := jwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.HS256})
 	if err != nil {
-		panic(err)
+		fmt.Printf("parsing JWT: %s\n", err)
+		return
 	}
 
 	cl := jwt.Claims{}
 	if err := tok.Claims(sharedKey, &cl); err != nil {
-		panic(err)
+		fmt.Printf("validating claims: %s\n", err)
+		return
 	}
 
 	err = cl.Validate(jwt.Expected{
@@ -127,7 +138,8 @@ func ExampleClaims_Validate_withParse() {
 		Subject: "subject",
 	})
 	if err != nil {
-		panic(err)
+		fmt.Printf("validating claims: %s\n", err)
+		return
 	}
 
 	fmt.Printf("valid!")
@@ -135,10 +147,11 @@ func ExampleClaims_Validate_withParse() {
 }
 
 func ExampleSigned() {
-	key := []byte("secret")
+	key := []byte("0102030405060708090A0B0C0D0E0F10")
 	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: key}, (&jose.SignerOptions{}).WithType("JWT"))
 	if err != nil {
-		panic(err)
+		fmt.Printf("making signer: %s\n", err)
+		return
 	}
 
 	cl := jwt.Claims{
@@ -149,18 +162,20 @@ func ExampleSigned() {
 	}
 	raw, err := jwt.Signed(sig).Claims(cl).Serialize()
 	if err != nil {
-		panic(err)
+		fmt.Printf("signing JWT: %s\n", err)
+		return
 	}
 
 	fmt.Println(raw)
-	// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsibGVlbGEiLCJmcnkiXSwiaXNzIjoiaXNzdWVyIiwibmJmIjoxNDUxNjA2NDAwLCJzdWIiOiJzdWJqZWN0In0.4PgCj0VO-uG_cb1mNA38NjJyp0N-NdGIDLoYelEkciw
+	// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsibGVlbGEiLCJmcnkiXSwiaXNzIjoiaXNzdWVyIiwibmJmIjoxNDUxNjA2NDAwLCJzdWIiOiJzdWJqZWN0In0.qEmW0Ehle1yO9XE7xZooC3AUVDF2NnJFDSgn4_6QzUo
 }
 
 func ExampleSigned_privateClaims() {
-	key := []byte("secret")
+	key := []byte("0102030405060708090A0B0C0D0E0F10")
 	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: key}, (&jose.SignerOptions{}).WithType("JWT"))
 	if err != nil {
-		panic(err)
+		fmt.Printf("making signer: %s\n", err)
+		return
 	}
 
 	cl := jwt.Claims{
@@ -181,11 +196,12 @@ func ExampleSigned_privateClaims() {
 
 	raw, err := jwt.Signed(sig).Claims(cl).Claims(privateCl).Serialize()
 	if err != nil {
-		panic(err)
+		fmt.Printf("signing JWT: %s\n", err)
+		return
 	}
 
 	fmt.Println(raw)
-	// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsibGVlbGEiLCJmcnkiXSwiY3VzdG9tIjoiY3VzdG9tIGNsYWltIHZhbHVlIiwiaXNzIjoiaXNzdWVyIiwibmJmIjoxNDUxNjA2NDAwLCJzdWIiOiJzdWJqZWN0In0.knXH3ReNJToS5XI7BMCkk80ugpCup3tOy53xq-ga47o
+	// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsibGVlbGEiLCJmcnkiXSwiY3VzdG9tIjoiY3VzdG9tIGNsYWltIHZhbHVlIiwiaXNzIjoiaXNzdWVyIiwibmJmIjoxNDUxNjA2NDAwLCJzdWIiOiJzdWJqZWN0In0.m6GDh-23MdwYKmzGHuWLMUcx874cGbyMG7nv-5J1ifk
 }
 
 func ExampleEncrypted() {
@@ -195,7 +211,8 @@ func ExampleEncrypted() {
 		(&jose.EncrypterOptions{}).WithType("JWT"),
 	)
 	if err != nil {
-		panic(err)
+		fmt.Printf("making encrypter: %s\n", err)
+		return
 	}
 
 	cl := jwt.Claims{
@@ -204,7 +221,8 @@ func ExampleEncrypted() {
 	}
 	raw, err := jwt.Encrypted(enc).Claims(cl).Serialize()
 	if err != nil {
-		panic(err)
+		fmt.Printf("encrypting JWT: %s\n", err)
+		return
 	}
 
 	fmt.Println(raw)
@@ -219,7 +237,8 @@ func ExampleSignedAndEncrypted() {
 		},
 		(&jose.EncrypterOptions{}).WithType("JWT").WithContentType("JWT"))
 	if err != nil {
-		panic(err)
+		fmt.Printf("making encrypter: %s\n", err)
+		return
 	}
 
 	cl := jwt.Claims{
@@ -228,7 +247,8 @@ func ExampleSignedAndEncrypted() {
 	}
 	raw, err := jwt.SignedAndEncrypted(rsaSigner, enc).Claims(cl).Serialize()
 	if err != nil {
-		panic(err)
+		fmt.Printf("encrypting and signing JWT: %s\n", err)
+		return
 	}
 
 	fmt.Println(raw)
@@ -246,23 +266,26 @@ func ExampleSigned_multipleClaims() {
 	}
 	raw, err := jwt.Signed(signer).Claims(c).Claims(c2).Serialize()
 	if err != nil {
-		panic(err)
+		fmt.Printf("validating claims: %s\n", err)
+		return
 	}
 
 	fmt.Println(raw)
-	// Output: eyJhbGciOiJIUzI1NiJ9.eyJTY29wZXMiOlsiZm9vIiwiYmFyIl0sImlzcyI6Imlzc3VlciIsInN1YiI6InN1YmplY3QifQ.esKOIsmwkudr_gnfnB4SngxIr-7pspd5XzG3PImfQ6Y
+	// Output: eyJhbGciOiJIUzI1NiJ9.eyJTY29wZXMiOlsiZm9vIiwiYmFyIl0sImlzcyI6Imlzc3VlciIsInN1YiI6InN1YmplY3QifQ.9VjIUvZ8VPFg1mMPq0kTbN7CpVOfn-WChY9RAVu-I6o
 }
 
 func ExampleJSONWebToken_Claims_map() {
-	raw := `eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJzdWJqZWN0In0.gpHyA1B1H6X4a4Edm9wo7D3X2v3aLSDBDG2_5BzXYe0`
+	raw := `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJzdWJqZWN0In0.OFD0iVfPczqWBA_TRi1jGB5PF699eekcHt4D6qNoimc`
 	tok, err := jwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.HS256})
 	if err != nil {
-		panic(err)
+		fmt.Printf("parsing JWT: %s\n", err)
+		return
 	}
 
 	out := make(map[string]interface{})
 	if err := tok.Claims(sharedKey, &out); err != nil {
-		panic(err)
+		fmt.Printf("validating claims: %s\n", err)
+		return
 	}
 
 	fmt.Printf("iss: %s, sub: %s\n", out["iss"], out["sub"])
@@ -270,21 +293,23 @@ func ExampleJSONWebToken_Claims_map() {
 }
 
 func ExampleJSONWebToken_Claims_multiple() {
-	raw := `eyJhbGciOiJIUzI1NiJ9.eyJTY29wZXMiOlsiZm9vIiwiYmFyIl0sImlzcyI6Imlzc3VlciIsInN1YiI6InN1YmplY3QifQ.esKOIsmwkudr_gnfnB4SngxIr-7pspd5XzG3PImfQ6Y`
+	raw := `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJpc3N1ZXIiLCJzY29wZXMiOlsiczEiLCJzMiJdLCJzdWIiOiJzdWJqZWN0In0.O9XxAYZsxXxWpTftO75vLpyYZ1g7FHxBvyvctGg3Ih0`
 	tok, err := jwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.HS256})
 	if err != nil {
-		panic(err)
+		fmt.Printf("parsing JWT: %s\n", err)
+		return
 	}
 
 	out := jwt.Claims{}
 	out2 := struct {
-		Scopes []string
+		Scopes []string `json:"scopes"`
 	}{}
 	if err := tok.Claims(sharedKey, &out, &out2); err != nil {
-		panic(err)
+		fmt.Printf("validating claims: %s\n", err)
+		return
 	}
 	fmt.Printf("iss: %s, sub: %s, scopes: %s\n", out.Issuer, out.Subject, strings.Join(out2.Scopes, ","))
-	// Output: iss: issuer, sub: subject, scopes: foo,bar
+	// Output: iss: issuer, sub: subject, scopes: s1,s2
 }
 
 func mustUnmarshalRSA(data string) *rsa.PrivateKey {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	hmacSignedToken                = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWJqZWN0IiwiaXNzIjoiaXNzdWVyIiwic2NvcGVzIjpbInMxIiwiczIiXX0.Y6_PfQHrzRJ_Vlxij5VI07-pgDIuJNN3Z_g5sSaGQ0c`
+	hmacSignedToken                string
 	rsaSignedToken                 = `eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJzY29wZXMiOlsiczEiLCJzMiJdLCJzdWIiOiJzdWJqZWN0In0.UDDtyK9gC9kyHltcP7E_XODsnqcJWZIiXeGmSAH7SE9YKy3N0KSfFIN85dCNjTfs6zvy4rkrCHzLB7uKAtzMearh3q7jL4nxbhUMhlUcs_9QDVoN4q_j58XmRqBqRnBk-RmDu9TgcV8RbErP4awpIhwWb5UU-hR__4_iNbHdKqwSUPDKYGlf5eicuiYrPxH8mxivk4LRD-vyRdBZZKBt0XIDnEU4TdcNCzAXojkftqcFWYsczwS8R4JHd1qYsMyiaWl4trdHZkO4QkeLe34z4ZAaPMt3wE-gcU-VoqYTGxz-K3Le2VaZ0r3j_z6bOInsv0yngC_cD1dCXMyQJWnWjQ`
 	rsaSignedTokenWithKid          = `eyJhbGciOiJSUzI1NiIsImtpZCI6ImZvb2JhciJ9.eyJpc3MiOiJpc3N1ZXIiLCJzY29wZXMiOlsiczEiLCJzMiJdLCJzdWIiOiJzdWJqZWN0In0.RxZhTRfPDb6UJ58FwvC89GgJGC8lAO04tz5iLlBpIJsyPZB0X_UgXSj0SGVFm2jbP_i-ZVH4HFC2fMB1n-so9CnCOpunWwhYNdgF6ewQJ0ADTWwfDGsK12UOmyT2naaZN8ZUBF8cgPtOgdWqQjk2Ng9QFRJxlUuKYczBp7vjWvgX8WMwQcaA-eK7HtguR4e9c4FMbeFK8Soc4jCsVTjIKdSn9SErc42gFu65NI1hZ3OPe_T7AZqdDjCkJpoiJ65GdD_qvGkVndJSEcMp3riXQpAy0JbctVkYecdFaGidbxHRrdcQYHtKn-XGMCh2uoBKleUr1fTMiyCGPQQesy3xHw`
 	invalidPayloadSignedToken      = `eyJhbGciOiJIUzI1NiJ9.aW52YWxpZC1wYXlsb2Fk.ScBKKm18jcaMLGYDNRUqB5gVMRZl4DM6dh3ShcxeNgY`
@@ -41,6 +41,19 @@ var (
 
 type customClaims struct {
 	Scopes []string `json:"scopes,omitempty"`
+}
+
+func init() {
+	var err error
+	hmacSignedToken, err = Signed(hmacSigner).Claims(Claims{
+		Subject: "subject",
+		Issuer:  "issuer",
+	}).Claims(customClaims{
+		Scopes: []string{"s1", "s2"},
+	}).Serialize()
+	if err != nil {
+		panic(err)
+	}
 }
 
 func TestGetClaimsWithoutVerification(t *testing.T) {

--- a/signing.go
+++ b/signing.go
@@ -49,6 +49,11 @@ type Signer interface {
 //   - JSONWebKey
 //   - []byte (an HMAC key)
 //   - Any type that satisfies the OpaqueSigner interface
+//
+// If the key is an HMAC key, it must have at least as many bytes as the relevant hash output:
+//   - HS256: 32 bytes
+//   - HS384: 48 bytes
+//   - HS512: 64 bytes
 type SigningKey struct {
 	Algorithm SignatureAlgorithm
 	Key       interface{}
@@ -355,6 +360,11 @@ func (ctx *genericSigner) Options() SignerOptions {
 //   - JSONWebKey
 //   - []byte (an HMAC key)
 //   - Any type that implements the OpaqueVerifier interface.
+//
+// If the key is an HMAC key, it must have at least as many bytes as the relevant hash output:
+//   - HS256: 32 bytes
+//   - HS384: 48 bytes
+//   - HS512: 64 bytes
 func (obj JSONWebSignature) Verify(verificationKey interface{}) ([]byte, error) {
 	err := obj.DetachedVerify(obj.payload, verificationKey)
 	if err != nil {

--- a/signing_test.go
+++ b/signing_test.go
@@ -109,10 +109,12 @@ func TestRoundtripsJWS(t *testing.T) {
 		signingKey, verificationKey := GenerateSigningTestKey(alg)
 
 		for i, serializer := range serializers {
-			err := RoundtripJWS(alg, serializer, corrupter, signingKey, verificationKey, "test_nonce")
-			if err != nil {
-				t.Error(err, alg, i)
-			}
+			t.Run(fmt.Sprintf("RoundTripsJWS%d-%s", i, alg), func(t *testing.T) {
+				err := RoundtripJWS(alg, serializer, corrupter, signingKey, verificationKey, "test_nonce")
+				if err != nil {
+					t.Error(err)
+				}
+			})
 		}
 	}
 }
@@ -235,6 +237,8 @@ func TestMultiRecipientJWS(t *testing.T) {
 	sharedKey := []byte{
 		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 	}
 	jwkSharedKey := JSONWebKey{
 		KeyID: "123",
@@ -304,7 +308,7 @@ func GenerateSigningTestKey(sigAlg SignatureAlgorithm) (sig, ver interface{}) {
 		sig = rsaTestKey
 		ver = &rsaTestKey.PublicKey
 	case HS256, HS384, HS512:
-		sig, _, _ = randomKeyGenerator{size: 16}.genKey()
+		sig, _, _ = randomKeyGenerator{size: 64}.genKey()
 		ver = sig
 	case ES256:
 		key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/symmetric.go
+++ b/symmetric.go
@@ -454,7 +454,7 @@ func (ctx *symmetricKeyCipher) decryptKey(headers rawHeader, recipient *recipien
 func (ctx symmetricMac) signPayload(payload []byte, alg SignatureAlgorithm) (Signature, error) {
 	mac, err := ctx.hmac(payload, alg)
 	if err != nil {
-		return Signature{}, errors.New("go-jose/go-jose: failed to compute hmac")
+		return Signature{}, err
 	}
 
 	return Signature{
@@ -486,12 +486,24 @@ func (ctx symmetricMac) verifyPayload(payload []byte, mac []byte, alg SignatureA
 func (ctx symmetricMac) hmac(payload []byte, alg SignatureAlgorithm) ([]byte, error) {
 	var hash func() hash.Hash
 
+	// https://datatracker.ietf.org/doc/html/rfc7518#section-3.2
+	// A key of the same size as the hash output (for instance, 256 bits for
+	// "HS256") or larger MUST be used
 	switch alg {
 	case HS256:
+		if len(ctx.key)*8 < 256 {
+			return nil, ErrInvalidKeySize
+		}
 		hash = sha256.New
 	case HS384:
+		if len(ctx.key)*8 < 384 {
+			return nil, ErrInvalidKeySize
+		}
 		hash = sha512.New384
 	case HS512:
+		if len(ctx.key)*8 < 512 {
+			return nil, ErrInvalidKeySize
+		}
 		hash = sha512.New
 	default:
 		return nil, ErrUnsupportedAlgorithm


### PR DESCRIPTION
Update the test cases that were using undersized keys. For `hmacSignedToken`, since it had to be regenerated anyhow, move generation into an `init()` function.

For the example tests, replace panics with print and exit. This allows multiple tests to fail during a given run, since example tests do not catch panics in the same way ordinary tests do.

Fixes #83