### PR TITLE
Define error values for missing x5c header and unsupported elliptic curves

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -71,6 +71,12 @@ var (
 	// ErrUnprotectedNonce indicates that while parsing a JWS or JWE object, a
 	// nonce header parameter was included in an unprotected header object.
 	ErrUnprotectedNonce = errors.New("go-jose/go-jose: Nonce parameter included in unprotected header")
+
+	// ErrMissingX5cHeader indicates that the JWT header is missing x5c headers.
+	ErrMissingX5cHeader = errors.New("go-jose/go-jose: no x5c header present in message")
+
+	// ErrUnsupportedEllipticCurve indicates unsupported or unknown elliptic curve has been found.
+	ErrUnsupportedEllipticCurve = errors.New("go-jose/go-jose: unsupported/unknown elliptic curve")
 )
 
 // Key management algorithms
@@ -199,7 +205,7 @@ type Header struct {
 // not be validated with the given verify options.
 func (h Header) Certificates(opts x509.VerifyOptions) ([][]*x509.Certificate, error) {
 	if len(h.certificates) == 0 {
-		return nil, errors.New("go-jose/go-jose: no x5c header present in message")
+		return nil, ErrMissingX5cHeader
 	}
 
 	leaf := h.certificates[0]
@@ -501,7 +507,7 @@ func curveName(crv elliptic.Curve) (string, error) {
 	case elliptic.P521():
 		return "P-521", nil
 	default:
-		return "", fmt.Errorf("go-jose/go-jose: unsupported/unknown elliptic curve")
+		return "", ErrUnsupportedEllipticCurve
 	}
 }
 


### PR DESCRIPTION
Most of the errors in the shared source have a dedicated error value
except for a couple that got away:
* x5c header missing in the JWT header
* An unsupported/unknown elliptic curve is found

This commit defines the error values for those cases.

This would be helpful to https://github.com/distribution/distribution project when discriminating between different errors during token validation.