### PR TITLE
Return more descriptive error when JWK matching `kid` not found in JWKS

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -459,7 +459,10 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 		return nil, fmt.Errorf("go-jose/go-jose: unsupported crit header")
 	}
 
-	key := tryJWKS(decryptionKey, obj.Header)
+	key, err := tryJWKS(decryptionKey, obj.Header)
+	if err != nil {
+		return nil, err
+	}
 	decrypter, err := newDecrypter(key)
 	if err != nil {
 		return nil, err
@@ -529,7 +532,10 @@ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Heade
 		return -1, Header{}, nil, fmt.Errorf("go-jose/go-jose: unsupported crit header")
 	}
 
-	key := tryJWKS(decryptionKey, obj.Header)
+	key, err := tryJWKS(decryptionKey, obj.Header)
+	if err != nil {
+		return -1, Header{}, nil, err
+	}
 	decrypter, err := newDecrypter(key)
 	if err != nil {
 		return -1, Header{}, nil, err

--- a/jwk.go
+++ b/jwk.go
@@ -779,7 +779,13 @@ func (key rawJSONWebKey) symmetricKey() ([]byte, error) {
 	return key.K.bytes(), nil
 }
 
-func tryJWKS(key interface{}, headers ...Header) interface{} {
+var (
+	// ErrJWKSKidNotFound is returned when a JWKS does not contain a JWK with a
+	// key ID which matches one in the provided tokens headers.
+	ErrJWKSKidNotFound = errors.New("go-jose/go-jose: JWK with matching kid not found in JWKS")
+)
+
+func tryJWKS(key interface{}, headers ...Header) (interface{}, error) {
 	var jwks JSONWebKeySet
 
 	switch jwksType := key.(type) {
@@ -788,9 +794,11 @@ func tryJWKS(key interface{}, headers ...Header) interface{} {
 	case JSONWebKeySet:
 		jwks = jwksType
 	default:
-		return key
+		// If the specified key is not a JWKS, return as is.
+		return key, nil
 	}
 
+	// Determine the KID to search for from the headers.
 	var kid string
 	for _, header := range headers {
 		if header.KeyID != "" {
@@ -799,14 +807,17 @@ func tryJWKS(key interface{}, headers ...Header) interface{} {
 		}
 	}
 
+	// If no KID is specified in the headers, reject.
 	if kid == "" {
-		return key
+		return nil, ErrJWKSKidNotFound
 	}
 
+	// Find the JWK with the matching KID. If no JWK with the specified KID is
+	// found, reject.
 	keys := jwks.Key(kid)
 	if len(keys) == 0 {
-		return key
+		return nil, ErrJWKSKidNotFound
 	}
 
-	return keys[0].Key
+	return keys[0].Key, nil
 }

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -21,8 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	jose "github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/assert"
+
+	jose "github.com/go-jose/go-jose/v4"
 )
 
 var (
@@ -108,6 +109,27 @@ func TestDecodeTokenWithJWKS(t *testing.T) {
 		if assert.NoError(t, tok.Claims(*jwks, &cl)) {
 			assert.Equal(t, expected, cl)
 		}
+	}
+}
+
+// TestDecodeTokenWithMismatchedJWKSKID tests a case where the JWT has a KID
+// header which does not match any of the keys in the JWKS.
+func TestDecodeTokenWithMismatchedJWKSKID(t *testing.T) {
+	jwks := &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				KeyID: "does-not-match",
+				Key:   &testPrivRSAKey1.PublicKey,
+			},
+		},
+	}
+
+	tok, err := ParseSigned(rsaSignedTokenWithKid, []jose.SignatureAlgorithm{jose.RS256})
+	if assert.NoError(t, err, "Error parsing signed token.") {
+		cl := make(map[string]interface{})
+		err := tok.Claims(jwks, &cl)
+		assert.Error(t, err, "Expected error when JWT KID does not match any key in JWKS.")
+		assert.ErrorIs(t, err, jose.ErrJWKSKidNotFound)
 	}
 }
 

--- a/signing.go
+++ b/signing.go
@@ -390,7 +390,10 @@ func (obj JSONWebSignature) UnsafePayloadWithoutVerification() []byte {
 // The verificationKey argument must have one of the types allowed for the
 // verificationKey argument of JSONWebSignature.Verify().
 func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey interface{}) error {
-	key := tryJWKS(verificationKey, obj.headers()...)
+	key, err := tryJWKS(verificationKey, obj.headers()...)
+	if err != nil {
+		return err
+	}
 	verifier, err := newVerifier(key)
 	if err != nil {
 		return err
@@ -455,7 +458,10 @@ func (obj JSONWebSignature) VerifyMulti(verificationKey interface{}) (int, Signa
 // The verificationKey argument must have one of the types allowed for the
 // verificationKey argument of JSONWebSignature.Verify().
 func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey interface{}) (int, Signature, error) {
-	key := tryJWKS(verificationKey, obj.headers()...)
+	key, err := tryJWKS(verificationKey, obj.headers()...)
+	if err != nil {
+		return -1, Signature{}, err
+	}
 	verifier, err := newVerifier(key)
 	if err != nil {
 		return -1, Signature{}, err


### PR DESCRIPTION
Closes https://github.com/go-jose/go-jose/issues/127

Returns a more descriptive error as the current error is fairly cryptic when the KID header within a JWT does not match the KID of any JWK in a JWKS.
