### PR TITLE
doc: note OpaqueKeyEncrypter can't be implemented

### DIFF
--- a/opaque.go
+++ b/opaque.go
@@ -83,6 +83,9 @@ func (o *opaqueVerifier) verifyPayload(payload []byte, signature []byte, alg Sig
 }
 
 // OpaqueKeyEncrypter is an interface that supports encrypting keys with an opaque key.
+//
+// Note: this cannot currently be implemented outside this package because of its
+// unexported method.
 type OpaqueKeyEncrypter interface {
 	// KeyID returns the kid
 	KeyID() string


### PR DESCRIPTION
Also, remove TestOpaqueKeyRoundtripJWE test case, which is expensive (because it incidentally uses the large default PBES2Count) and isn't testing reachable code. It can be restored if/when we fix the API for OpaqueKeyEncrypter so it can be implemented (and possibly pass along PBES2 parameters).

Fixes #112, updates #114

Note: I tried simply exporting `encryptKey` as `EncryptKey` and adding parameters, but it wound up getting more involved because we would also have to export the return type `recipientInfo`, which in turn contains the unexported `*rawHeader`. For now this documents the status quo (OpaqueKeyEncrypter doesn't work) and speeds up our tests dramatically (11s on my machine).