### PR TITLE
JSONWebKeySet: ignore unsupported key types

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -177,6 +177,8 @@ func (k JSONWebKey) MarshalJSON() ([]byte, error) {
 var errUnsupportedJWK = errors.New("go-jose/go-jose: unsupported json web key")
 
 // UnmarshalJSON reads a key from its JSON representation.
+//
+// Returns ErrUnsupportedKeyType for unrecognized or unsupported "kty" header values.
 func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 	var raw rawJSONWebKey
 	err = json.Unmarshal(data, &raw)
@@ -258,9 +260,7 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		//     (key type) values that are not understood by them, that are missing
 		//     required members, or for which values are out of the supported
 		//     ranges.
-
-		// Fail unmarshal with errUnsupportedJWK
-		return errUnsupportedJWK
+		return ErrUnsupportedKeyType
 	}
 
 	if certPub != nil && keyPub != nil {
@@ -379,9 +379,8 @@ func (s *JSONWebKeySet) UnmarshalJSON(data []byte) (err error) {
 		var k JSONWebKey
 		err = json.Unmarshal(rk, &k)
 		if err != nil {
-			// Skip key and continue unmarshalling the key set if key unmarshal
-			// failed because of unsupported key type or parameters.
-			if !errors.Is(err, errUnsupportedJWK) {
+			// Skip key and continue unmarshalling the rest of the JWK Set
+			if !errors.Is(err, ErrUnsupportedKeyType) {
 				return err
 			}
 		} else {

--- a/jwk.go
+++ b/jwk.go
@@ -363,6 +363,8 @@ func (s *JSONWebKeySet) Key(kid string) []JSONWebKey {
 }
 
 func (s *JSONWebKeySet) UnmarshalJSON(data []byte) (err error) {
+	s.Keys = nil
+
 	type rawJSONWebKeySet struct {
 		Keys []json.RawMessage `json:"keys"`
 	}

--- a/jwk.go
+++ b/jwk.go
@@ -174,6 +174,8 @@ func (k JSONWebKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
+var errUnsupportedJWK = errors.New("go-jose/go-jose: unsupported json web key")
+
 // UnmarshalJSON reads a key from its JSON representation.
 func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 	var raw rawJSONWebKey
@@ -228,7 +230,7 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		}
 		key, err = raw.symmetricKey()
 	case "OKP":
-		if raw.Crv == "Ed25519" && raw.X != nil {
+		if raw.Crv == "Ed25519" {
 			if raw.D != nil {
 				key, err = raw.edPrivateKey()
 				if err == nil {
@@ -238,15 +240,27 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 				key, err = raw.edPublicKey()
 				keyPub = key
 			}
-		} else {
-			err = fmt.Errorf("go-jose/go-jose: unknown curve %s'", raw.Crv)
 		}
-	default:
-		err = fmt.Errorf("go-jose/go-jose: unknown json web key type '%s'", raw.Kty)
+	case "":
+		// kty MUST be present
+		err = fmt.Errorf("go-jose/go-jose: missing json web key type")
 	}
 
 	if err != nil {
 		return
+	}
+
+	if key == nil {
+		// RFC 7517:
+		// 5.  JWK Set Format
+		// ...
+		//     Implementations SHOULD ignore JWKs within a JWK Set that use "kty"
+		//     (key type) values that are not understood by them, that are missing
+		//     required members, or for which values are out of the supported
+		//     ranges.
+
+		// Fail unmarshal with errUnsupportedJWK
+		return errUnsupportedJWK
 	}
 
 	if certPub != nil && keyPub != nil {
@@ -346,6 +360,34 @@ func (s *JSONWebKeySet) Key(kid string) []JSONWebKey {
 	}
 
 	return keys
+}
+
+func (s *JSONWebKeySet) UnmarshalJSON(data []byte) (err error) {
+	type rawJSONWebKeySet struct {
+		Keys []json.RawMessage `json:"keys"`
+	}
+
+	var rs rawJSONWebKeySet
+	err = json.Unmarshal(data, &rs)
+	if err != nil {
+		return err
+	}
+
+	for _, rk := range rs.Keys {
+		var k JSONWebKey
+		err = json.Unmarshal(rk, &k)
+		if err != nil {
+			// Skip key and continue unmarshalling the key set if key unmarshal
+			// failed because of unsupported key type or parameters.
+			if !errors.Is(err, errUnsupportedJWK) {
+				return err
+			}
+		} else {
+			s.Keys = append(s.Keys, k)
+		}
+	}
+
+	return nil
 }
 
 const rsaThumbprintTemplate = `{"e":"%s","kty":"RSA","n":"%s"}`

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -926,6 +926,16 @@ func TestMarshalUnmarshalJWKSet(t *testing.T) {
 	if !bytes.Equal(jsonbar, jsonbar2) {
 		t.Error("roundtrip should not lose information")
 	}
+
+	set3 := JSONWebKeySet{Keys: []JSONWebKey{jwk1}}
+	err = json.Unmarshal(jsonbar, &set3)
+	if err != nil {
+		t.Fatal("problem unmarshalling set", err)
+	}
+
+	if len(set3.Keys) != 2 {
+		t.Error("unmarshaling should clear any existing keys")
+	}
 }
 
 func TestJWKSetKey(t *testing.T) {

--- a/shared.go
+++ b/shared.go
@@ -53,9 +53,10 @@ var (
 	ErrUnsupportedAlgorithm = errors.New("go-jose/go-jose: unknown/unsupported algorithm")
 
 	// ErrUnsupportedKeyType indicates that the given key type/format is not
-	// supported. This occurs when trying to instantiate an encrypter and passing
-	// it a key of an unrecognized type or with unsupported parameters, such as
-	// an RSA private key with more than two primes.
+	// supported. This occurs when parsing a JWK with an unsupported key type (kty),
+	// or instantiating a signer or encrypter with an unsupported key type in Go
+	// (e.g. *dsa.PrivateKey), or a key type in Go that doesn't match the requested
+	// algorithm.
 	ErrUnsupportedKeyType = errors.New("go-jose/go-jose: unsupported key type/format")
 
 	// ErrInvalidKeySize indicates that the given key is not the correct size


### PR DESCRIPTION
Port of #26 to main branch, along with some fixes:

 - reset the list of keys when unmarshaling
 - return UnsupportedKeyType instead of internal error
 - update tests to separately test JWK parsing (should return error for unsupported) and JWK Set parsing (should ignore unsupported JWKs)