### PR TITLE
Revert #26 (ignore unsupported JWKs in Sets)

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -174,8 +174,6 @@ func (k JSONWebKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-var errUnsupportedJWK = errors.New("go-jose/go-jose: unsupported json web key")
-
 // UnmarshalJSON reads a key from its JSON representation.
 func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 	var raw rawJSONWebKey
@@ -230,7 +228,7 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		}
 		key, err = raw.symmetricKey()
 	case "OKP":
-		if raw.Crv == "Ed25519" {
+		if raw.Crv == "Ed25519" && raw.X != nil {
 			if raw.D != nil {
 				key, err = raw.edPrivateKey()
 				if err == nil {
@@ -240,27 +238,15 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 				key, err = raw.edPublicKey()
 				keyPub = key
 			}
+		} else {
+			err = fmt.Errorf("go-jose/go-jose: unknown curve %s'", raw.Crv)
 		}
-	case "":
-		// kty MUST be present
-		err = fmt.Errorf("go-jose/go-jose: missing json web key type")
+	default:
+		err = fmt.Errorf("go-jose/go-jose: unknown json web key type '%s'", raw.Kty)
 	}
 
 	if err != nil {
 		return
-	}
-
-	if key == nil {
-		// RFC 7517:
-		// 5.  JWK Set Format
-		// ...
-		//     Implementations SHOULD ignore JWKs within a JWK Set that use "kty"
-		//     (key type) values that are not understood by them, that are missing
-		//     required members, or for which values are out of the supported
-		//     ranges.
-
-		// Fail unmarshal with errUnsupportedJWK
-		return errUnsupportedJWK
 	}
 
 	if certPub != nil && keyPub != nil {
@@ -360,34 +346,6 @@ func (s *JSONWebKeySet) Key(kid string) []JSONWebKey {
 	}
 
 	return keys
-}
-
-func (s *JSONWebKeySet) UnmarshalJSON(data []byte) (err error) {
-	type rawJSONWebKeySet struct {
-		Keys []json.RawMessage `json:"keys"`
-	}
-
-	var rs rawJSONWebKeySet
-	err = json.Unmarshal(data, &rs)
-	if err != nil {
-		return err
-	}
-
-	for _, rk := range rs.Keys {
-		var k JSONWebKey
-		err = json.Unmarshal(rk, &k)
-		if err != nil {
-			// Skip key and continue unmarshalling the key set if key unmarshal
-			// failed because of unsupported key type or parameters.
-			if !errors.Is(err, errUnsupportedJWK) {
-				return err
-			}
-		} else {
-			s.Keys = append(s.Keys, k)
-		}
-	}
-
-	return nil
 }
 
 const rsaThumbprintTemplate = `{"e":"%s","kty":"RSA","n":"%s"}`

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -703,12 +703,6 @@ func TestWebKeyVectorsInvalid(t *testing.T) {
 		`{"kty":"EC","crv":"P-256","d":"XXX"}`,
 		`{"kty":"EC","crv":"ABC","d":"dGVzdA","x":"dGVzdA"}`,
 		`{"kty":"EC","crv":"P-256","d":"dGVzdA","x":"dGVzdA"}`,
-		// Invalid oct key
-		`{"kty":"oct"}`,
-		`{"kty":"oct","k":"%not-base64url-encoded*"}`,
-		// Invalid OKP key
-		`{"kty":"OKP","crv":"Ed25519"}`,
-		`{"kty":"OKP","crv":"Ed25519","x":"%not-base64url-encoded*"}`,
 	}
 
 	for _, key := range keys {
@@ -716,26 +710,6 @@ func TestWebKeyVectorsInvalid(t *testing.T) {
 		err := jwk2.UnmarshalJSON([]byte(key))
 		if err == nil {
 			t.Error("managed to parse invalid key:", key)
-		}
-	}
-}
-
-func TestWebKeyVectorsUnsupported(t *testing.T) {
-	keys := []string{
-		// Unknown kty
-		`{"kty": "XXX"}`,
-		// Unsupported OKP curve
-		`{"kty": "OKP", "crv": "X25519", "x": "89abcdef"}`,
-	}
-
-	for _, key := range keys {
-		var jwk2 JSONWebKey
-		err := jwk2.UnmarshalJSON([]byte(key))
-		if err != nil {
-			t.Error("failed to parse key with unsupported type or algorithm:", key)
-		}
-		if jwk2.Valid() {
-			t.Error("unsupported key type or algorithm parsed into a valid key:", key)
 		}
 	}
 }


### PR DESCRIPTION
This reverts commit 3e2bbef724ae666f9e6691659bd46bc0c3e0c7aa, "Unmarshal jwk keys with unsupported key type or algorithm into empty ... (#26)"

I accidentally merged that PR into v3, but per our README, the v3 branch is getting security updates but not functionality updates.