### PR TITLE
v3: use latest Go releases

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.16.x"
-          - "1.21.5"
+          - "1.16"
+          - "1.21"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
         GO_VERSION:
           # go1.16 does not meet the minimum requirements to run govulncheck so
           # we will skip testing against it.
-          - "1.21.5"
+          - "1.21"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/go-jose/go-jose/v3
 
-go 1.12
+// https://pkg.go.dev/vuln/GO-2024-2598
+// crypto/x509.Certificate.Verify panics on unknown public key algorithm.
+// Fixed in Go 1.21.8
+go 1.21.8
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
In CI, specify only a minor version, so GitHub Actions will use the latest in
that minor version series.

In go.mod, require a version of Go with the Certificate.Verify panic patched.