### PR TITLE
Remove unused JWK error type

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -243,7 +243,7 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		}
 	case "":
 		// kty MUST be present
-		err = fmt.Errorf("go-jose/go-jose: missing json web key type")
+		return errors.New("go-jose/go-jose: missing json web key type")
 	}
 
 	if err != nil {

--- a/jwk.go
+++ b/jwk.go
@@ -174,8 +174,6 @@ func (k JSONWebKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-var errUnsupportedJWK = errors.New("go-jose/go-jose: unsupported json web key")
-
 // UnmarshalJSON reads a key from its JSON representation.
 //
 // Returns ErrUnsupportedKeyType for unrecognized or unsupported "kty" header values.


### PR DESCRIPTION
As noted here https://github.com/go-jose/go-jose/pull/130#pullrequestreview-2179088936

The error type `errUnsupportedJWK` is never used.

In addition, swapped out a use of `fmt.Errorf()` with the slightly more performant `errors.New()`.
