### PR TITLE
Revert #130: JSONWebKeySet: ignore unsupported key types

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -174,11 +174,7 @@ func (k JSONWebKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-var errUnsupportedJWK = errors.New("go-jose/go-jose: unsupported json web key")
-
 // UnmarshalJSON reads a key from its JSON representation.
-//
-// Returns ErrUnsupportedKeyType for unrecognized or unsupported "kty" header values.
 func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 	var raw rawJSONWebKey
 	err = json.Unmarshal(data, &raw)
@@ -232,7 +228,7 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		}
 		key, err = raw.symmetricKey()
 	case "OKP":
-		if raw.Crv == "Ed25519" {
+		if raw.Crv == "Ed25519" && raw.X != nil {
 			if raw.D != nil {
 				key, err = raw.edPrivateKey()
 				if err == nil {
@@ -242,25 +238,15 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 				key, err = raw.edPublicKey()
 				keyPub = key
 			}
+		} else {
+			err = fmt.Errorf("go-jose/go-jose: unknown curve %s'", raw.Crv)
 		}
-	case "":
-		// kty MUST be present
-		err = fmt.Errorf("go-jose/go-jose: missing json web key type")
+	default:
+		err = fmt.Errorf("go-jose/go-jose: unknown json web key type '%s'", raw.Kty)
 	}
 
 	if err != nil {
 		return
-	}
-
-	if key == nil {
-		// RFC 7517:
-		// 5.  JWK Set Format
-		// ...
-		//     Implementations SHOULD ignore JWKs within a JWK Set that use "kty"
-		//     (key type) values that are not understood by them, that are missing
-		//     required members, or for which values are out of the supported
-		//     ranges.
-		return ErrUnsupportedKeyType
 	}
 
 	if certPub != nil && keyPub != nil {
@@ -360,35 +346,6 @@ func (s *JSONWebKeySet) Key(kid string) []JSONWebKey {
 	}
 
 	return keys
-}
-
-func (s *JSONWebKeySet) UnmarshalJSON(data []byte) (err error) {
-	s.Keys = nil
-
-	type rawJSONWebKeySet struct {
-		Keys []json.RawMessage `json:"keys"`
-	}
-
-	var rs rawJSONWebKeySet
-	err = json.Unmarshal(data, &rs)
-	if err != nil {
-		return err
-	}
-
-	for _, rk := range rs.Keys {
-		var k JSONWebKey
-		err = json.Unmarshal(rk, &k)
-		if err != nil {
-			// Skip key and continue unmarshalling the rest of the JWK Set
-			if !errors.Is(err, ErrUnsupportedKeyType) {
-				return err
-			}
-		} else {
-			s.Keys = append(s.Keys, k)
-		}
-	}
-
-	return nil
 }
 
 const rsaThumbprintTemplate = `{"e":"%s","kty":"RSA","n":"%s"}`

--- a/jwk.go
+++ b/jwk.go
@@ -174,6 +174,8 @@ func (k JSONWebKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
+var errUnsupportedJWK = errors.New("go-jose/go-jose: unsupported json web key")
+
 // UnmarshalJSON reads a key from its JSON representation.
 //
 // Returns ErrUnsupportedKeyType for unrecognized or unsupported "kty" header values.
@@ -243,7 +245,7 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		}
 	case "":
 		// kty MUST be present
-		return errors.New("go-jose/go-jose: missing json web key type")
+		err = fmt.Errorf("go-jose/go-jose: missing json web key type")
 	}
 
 	if err != nil {

--- a/shared.go
+++ b/shared.go
@@ -53,10 +53,9 @@ var (
 	ErrUnsupportedAlgorithm = errors.New("go-jose/go-jose: unknown/unsupported algorithm")
 
 	// ErrUnsupportedKeyType indicates that the given key type/format is not
-	// supported. This occurs when parsing a JWK with an unsupported key type (kty),
-	// or instantiating a signer or encrypter with an unsupported key type in Go
-	// (e.g. *dsa.PrivateKey), or a key type in Go that doesn't match the requested
-	// algorithm.
+	// supported. This occurs when trying to instantiate an encrypter and passing
+	// it a key of an unrecognized type or with unsupported parameters, such as
+	// an RSA private key with more than two primes.
 	ErrUnsupportedKeyType = errors.New("go-jose/go-jose: unsupported key type/format")
 
 	// ErrInvalidKeySize indicates that the given key is not the correct size


### PR DESCRIPTION
As discussed in #136, this was a breaking change. Implementing `UnmarshalJSON` on `JSONWebKeySet` broke unmarshaling into structs that embed `JSONWebKeySet` and also include other fields (and that do not have `UnmarshalJSON` implementations themselves). Before #130, those fields would get unmarshaled using the default behavior for `encoding/json`. After #130, the custom `UnmarshalJSON` would get called for the whole parent struct, but because its receiver is the embedded `JSONWebKeySet` it would not be able to set any of the sibling fields.

Revert for now to undo the breakage. We should find another way to solve the problem of accepting unrecognized keys.