### PR TITLE
Remove export disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,6 @@ Package jose aims to provide an implementation of the Javascript Object Signing
 and Encryption set of standards. This includes support for JSON Web Encryption,
 JSON Web Signature, and JSON Web Token standards.
 
-**Disclaimer**: This library contains encryption software that is subject to
-the U.S. Export Administration Regulations. You may not export, re-export,
-transfer or download this code or any part of it in violation of any United
-States law, directive or regulation. In particular this software may not be
-exported or re-exported in any form or on any media to Iran, North Sudan,
-Syria, Cuba, or North Korea, or to denied persons or entities mentioned on any
-US maintained blocked list.
-
 ## Overview
 
 The implementation follows the


### PR DESCRIPTION
See https://www.linuxfoundation.org/resources/publications/understanding-us-export-controls-with-open-source-projects

As an oepn source project, we can make this globally available.

Also, there's not really any encryption software in go-jose - that's all in golang's crypto libraries.
