### PR TITLE
Better error message when compact signed JWT is blank

### DIFF
--- a/jws.go
+++ b/jws.go
@@ -327,6 +327,10 @@ func parseSignedCompact(
 	payload []byte,
 	signatureAlgorithms []SignatureAlgorithm,
 ) (*JSONWebSignature, error) {
+	if input == "" {
+		return nil, fmt.Errorf("go-jose/go-jose: expected compact JWS, got blank string")
+	}
+
 	parts := strings.Split(input, ".")
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("go-jose/go-jose: compact JWS format must have three parts")


### PR DESCRIPTION
This would have saved me some debugging time... maybe the next user can benefit.

Thanks very much for making `go-jose` available!