### PR TITLE
Document `signatureAlgorithms` argument

### DIFF
--- a/jws.go
+++ b/jws.go
@@ -81,7 +81,8 @@ type Signature struct {
 // not sure which signature algorithms your application might receive, consult the documentation of
 // the program which provides them or the protocol that you are implementing. You can also try
 // getting an example JWS and decoding it with a tool like https://jwt.io to see what its "alg"
-// header parameter indicates.
+// header parameter indicates. The signature on the JWS does not get validated during parsing. Call
+// Verify() after parsing to validate the signature and obtain the payload.
 //
 // https://datatracker.ietf.org/doc/html/rfc7515#section-7
 func ParseSigned(
@@ -102,7 +103,8 @@ func ParseSigned(
 // signature algorithms your application might receive, consult the documentation of the program
 // which provides them or the protocol that you are implementing. You can also try getting an
 // example JWS and decoding it with a tool like https://jwt.io to see what its "alg" header
-// parameter indicates.
+// parameter indicates. The signature on the JWS does not get validated during parsing. Call
+// Verify() after parsing to validate the signature and obtain the payload.
 //
 // https://datatracker.ietf.org/doc/html/rfc7515#section-7.1
 func ParseSignedCompact(
@@ -118,7 +120,8 @@ func ParseSignedCompact(
 // acceptable. If you're not sure which signature algorithms your application might receive, consult
 // the documentation of the program which provides them or the protocol that you are implementing.
 // You can also try getting an example JWS and decoding it with a tool like https://jwt.io to see
-// what its "alg" header parameter indicates.
+// what its "alg" header parameter indicates. The signature on the JWS does not get validated during
+// parsing. Call Verify() after parsing to validate the signature and obtain the payload.
 //
 // https://datatracker.ietf.org/doc/html/rfc7515#appendix-F
 func ParseDetached(

--- a/jws.go
+++ b/jws.go
@@ -75,7 +75,9 @@ type Signature struct {
 	original  *rawSignatureInfo
 }
 
-// ParseSigned parses a signed message in JWS Compact or JWS JSON Serialization.
+// ParseSigned parses a signed message in JWS Compact or JWS JSON Serialization. Validation fails if
+// the JWS is signed with an algorithm that isn't in the provided list of signature algorithms.
+// Applications should decide for themselves which signature algorithms are acceptable.
 //
 // https://datatracker.ietf.org/doc/html/rfc7515#section-7
 func ParseSigned(
@@ -90,7 +92,9 @@ func ParseSigned(
 	return parseSignedCompact(signature, nil, signatureAlgorithms)
 }
 
-// ParseSignedCompact parses a message in JWS Compact Serialization.
+// ParseSignedCompact parses a message in JWS Compact Serialization. Validation fails if the JWS is
+// signed with an algorithm that isn't in the provided list of signature algorithms. Applications
+// should decide for themselves which signature algorithms are acceptable.
 //
 // https://datatracker.ietf.org/doc/html/rfc7515#section-7.1
 func ParseSignedCompact(
@@ -101,6 +105,11 @@ func ParseSignedCompact(
 }
 
 // ParseDetached parses a signed message in compact serialization format with detached payload.
+// Validation fails if the JWS is signed with an algorithm that isn't in the provided list of
+// signature algorithms. Applications should decide for themselves which signature algorithms are
+// acceptable.
+//
+// https://datatracker.ietf.org/doc/html/rfc7515#appendix-F
 func ParseDetached(
 	signature string,
 	payload []byte,

--- a/jws.go
+++ b/jws.go
@@ -77,7 +77,11 @@ type Signature struct {
 
 // ParseSigned parses a signed message in JWS Compact or JWS JSON Serialization. Validation fails if
 // the JWS is signed with an algorithm that isn't in the provided list of signature algorithms.
-// Applications should decide for themselves which signature algorithms are acceptable.
+// Applications should decide for themselves which signature algorithms are acceptable. If you're
+// not sure which signature algorithms your application might receive, consult the documentation of
+// the program which provides them or the protocol that you are implementing. You can also try
+// getting an example JWS and decoding it with a tool like https://jwt.io to see what its "alg"
+// header parameter indicates.
 //
 // https://datatracker.ietf.org/doc/html/rfc7515#section-7
 func ParseSigned(
@@ -94,7 +98,11 @@ func ParseSigned(
 
 // ParseSignedCompact parses a message in JWS Compact Serialization. Validation fails if the JWS is
 // signed with an algorithm that isn't in the provided list of signature algorithms. Applications
-// should decide for themselves which signature algorithms are acceptable.
+// should decide for themselves which signature algorithms are acceptable.If you're not sure which
+// signature algorithms your application might receive, consult the documentation of the program
+// which provides them or the protocol that you are implementing. You can also try getting an
+// example JWS and decoding it with a tool like https://jwt.io to see what its "alg" header
+// parameter indicates.
 //
 // https://datatracker.ietf.org/doc/html/rfc7515#section-7.1
 func ParseSignedCompact(
@@ -107,7 +115,10 @@ func ParseSignedCompact(
 // ParseDetached parses a signed message in compact serialization format with detached payload.
 // Validation fails if the JWS is signed with an algorithm that isn't in the provided list of
 // signature algorithms. Applications should decide for themselves which signature algorithms are
-// acceptable.
+// acceptable. If you're not sure which signature algorithms your application might receive, consult
+// the documentation of the program which provides them or the protocol that you are implementing.
+// You can also try getting an example JWS and decoding it with a tool like https://jwt.io to see
+// what its "alg" header parameter indicates.
 //
 // https://datatracker.ietf.org/doc/html/rfc7515#appendix-F
 func ParseDetached(


### PR DESCRIPTION
The various `Parse` functions in `jws.go` that construct `jose.JSONWebSignature` take a slice of acceptable signature algorithms. We now document its purpose and usage. While I was in there, I also added a reference to RFC 7515 for detached paylods.

Fixes #162