### PR TITLE
Drop go-cmp dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/go-jose/go-jose/v4
 go 1.24
 
 require (
-	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
-github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/go-jose/go-jose/v4/json"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -316,8 +315,9 @@ func TestRoundtripX509(t *testing.T) {
 			jsonbar2, err := jwk2.MarshalJSON()
 			require.NoError(t, err)
 
-			require.Empty(t, cmp.Diff(jsonbar, jsonbar2))
 			if !bytes.Equal(jsonbar, jsonbar2) {
+				t.Logf("Original JSON: %s", string(jsonbar))
+				t.Logf("New JSON: %s", string(jsonbar2))
 				t.Error("roundtrip should not lose information")
 			}
 		})
@@ -364,7 +364,9 @@ func TestRoundtripX509Hex(t *testing.T) {
 	var j1, j2 map[string]interface{}
 	require.NoError(t, json.Unmarshal(js, &j1))
 	require.NoError(t, json.Unmarshal([]byte(output), &j2))
-	require.Empty(t, cmp.Diff(j1, j2))
+	if !reflect.DeepEqual(j1, j2) {
+		t.Errorf("Not equal after round trip: '%v' '%v'", j1, j2)
+	}
 }
 
 func TestCertificatesURL(t *testing.T) {
@@ -384,7 +386,9 @@ func TestCertificatesURL(t *testing.T) {
 	var j1, j2 map[string]interface{}
 	require.NoError(t, json.Unmarshal(js, &j1))
 	require.NoError(t, json.Unmarshal([]byte(urlJWK), &j2))
-	require.Empty(t, cmp.Diff(j1, j2))
+	if !reflect.DeepEqual(j1, j2) {
+		t.Errorf("Not equal after round trip: '%v' '%v'", j1, j2)
+	}
 
 	var invalidURLJWK = `{
    "kty":"RSA",


### PR DESCRIPTION
We only use it in a few small places.

Without cmp.Diff, we might not get as nice test failures, but it's not too hard to use an external diff tool if something were to break.