### PR TITLE
jws: improve performance and allocations for ParseSignedCompact

### DIFF
--- a/jwe.go
+++ b/jwe.go
@@ -288,11 +288,20 @@ func ParseEncryptedCompact(
 	keyAlgorithms []KeyAlgorithm,
 	contentEncryption []ContentEncryption,
 ) (*JSONWebEncryption, error) {
-	// Five parts is four separators
-	if strings.Count(input, ".") != 4 {
-		return nil, fmt.Errorf("go-jose/go-jose: compact JWE format must have five parts")
+	var parts [5]string
+	var ok bool
+
+	for i := range 4 {
+		parts[i], input, ok = strings.Cut(input, ".")
+		if !ok {
+			return nil, errors.New("go-jose/go-jose: compact JWE format must have five parts")
+		}
 	}
-	parts := strings.SplitN(input, ".", 5)
+	// Validate that the last part does not contain more dots
+	if strings.ContainsRune(input, '.') {
+		return nil, errors.New("go-jose/go-jose: compact JWE format must have five parts")
+	}
+	parts[4] = input
 
 	rawProtected, err := base64.RawURLEncoding.DecodeString(parts[0])
 	if err != nil {

--- a/jwe_test.go
+++ b/jwe_test.go
@@ -717,3 +717,12 @@ func TestJWEWithNullAlg(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func BenchmarkParseEncryptedCompat(b *testing.B) {
+	msg := "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkExMjhHQ00ifQ.dGVzdA.dGVzdA.dGVzdA.dGVzdA"
+	for b.Loop() {
+		if _, err := ParseEncryptedCompact(msg, []KeyAlgorithm{RSA_OAEP}, []ContentEncryption{A128GCM}); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/jws_test.go
+++ b/jws_test.go
@@ -749,3 +749,13 @@ func TestInvalidHMACKeySize(t *testing.T) {
 	_, err = s.Sign([]byte("Lorem ipsum dolor sit amet"))
 	assert.ErrorIs(t, err, ErrInvalidKeySize)
 }
+
+func BenchmarkParseSignedCompat(b *testing.B) {
+	raw := `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJzdWJqZWN0In0.OFD0iVfPczqWBA_TRi1jGB5PF699eekcHt4D6qNoimc`
+
+	for b.Loop() {
+		if _, err := ParseSignedCompact(raw, []SignatureAlgorithm{HS256}); err != nil {
+			panic(err)
+		}
+	}
+}


### PR DESCRIPTION
See also https://go-review.googlesource.com/c/oauth2/+/655455

name                  old time/op    new time/op    delta
ParseSignedCompat-16    1.95µs ± 1%    1.91µs ± 1%  -1.83%  (p=0.000 n=9+10)

name                  old alloc/op   new alloc/op   delta
ParseSignedCompat-16    3.26kB ± 0%    3.21kB ± 0%  -1.47%  (p=0.000 n=10+10)

name                  old allocs/op  new allocs/op  delta
ParseSignedCompat-16      45.0 ± 0%      44.0 ± 0%  -2.22%  (p=0.000 n=10+10)