### PR TITLE
Add missing quote to unknown curve message #170

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -239,7 +239,7 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 				keyPub = key
 			}
 		} else {
-			return fmt.Errorf("go-jose/go-jose: unknown curve %s'", raw.Crv)
+			return fmt.Errorf("go-jose/go-jose: unknown curve '%s'", raw.Crv)
 		}
 	default:
 		return fmt.Errorf("go-jose/go-jose: unknown json web key type '%s'", raw.Kty)


### PR DESCRIPTION
Added a missing quote to the unknown curve error message. 

Go test is passing - 
```
$ go test
PASS
ok      github.com/go-jose/go-jose/v4   4.432s
```

Go fmt is good too
```
$ go fmt 
$ echo $?
0
```