### PR TITLE
JWK unsupported error when unmarshalling

### DIFF
--- a/jwk_test.go
+++ b/jwk_test.go
@@ -27,6 +27,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
+	"errors"
 	"math/big"
 	"reflect"
 	"strings"
@@ -675,6 +676,15 @@ func TestWebKeyVectorsInvalid(t *testing.T) {
 		if err == nil {
 			t.Error("managed to parse invalid key:", key)
 		}
+	}
+}
+
+// TestJWKUnsupported checks for an error when parsing a JWK with an unsupported key type.
+func TestJWKUnsupported(t *testing.T) {
+	var jwk JSONWebKey
+	err := jwk.UnmarshalJSON([]byte(`{"kty": "XXX"}`))
+	if !errors.Is(err, ErrUnsupportedKeyType) {
+		t.Error("expected ErrUnsupportedKeyType, got:", err)
 	}
 }
 


### PR DESCRIPTION
While waiting for a breaking change release to merge this fix https://github.com/go-jose/go-jose/pull/130, it could be useful to return UnsupportedKeyType instead of internal error when unmarshalling JWK so that the library users might write their own JWKS umarshalling method to ignore unsupported key types, eg. https://github.com/zitadel/oidc/blob/045b59e5a55be97ba180fdaae96fb66302a03353/pkg/client/rp/jwks.go#L221-L235.