### PR TITLE
Restore Go 1.23 compatibility

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
+          - "1.23.x"
           - "1.24.x"
     runs-on: ubuntu-latest
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/go-jose/go-jose/v4
 
-go 1.24
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/crypto v0.39.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
+golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/jwe_test.go
+++ b/jwe_test.go
@@ -720,7 +720,7 @@ func TestJWEWithNullAlg(t *testing.T) {
 
 func BenchmarkParseEncryptedCompat(b *testing.B) {
 	msg := "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkExMjhHQ00ifQ.dGVzdA.dGVzdA.dGVzdA.dGVzdA"
-	for b.Loop() {
+	for range b.N {
 		if _, err := ParseEncryptedCompact(msg, []KeyAlgorithm{RSA_OAEP}, []ContentEncryption{A128GCM}); err != nil {
 			panic(err)
 		}

--- a/jws_test.go
+++ b/jws_test.go
@@ -753,7 +753,7 @@ func TestInvalidHMACKeySize(t *testing.T) {
 func BenchmarkParseSignedCompat(b *testing.B) {
 	raw := `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJzdWJqZWN0In0.OFD0iVfPczqWBA_TRi1jGB5PF699eekcHt4D6qNoimc`
 
-	for b.Loop() {
+	for range b.N {
 		if _, err := ParseSignedCompact(raw, []SignatureAlgorithm{HS256}); err != nil {
 			panic(err)
 		}

--- a/symmetric.go
+++ b/symmetric.go
@@ -21,7 +21,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
-	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -329,7 +328,7 @@ func (ctx *symmetricKeyCipher) encryptKey(cek []byte, alg KeyAlgorithm) (recipie
 
 		// derive key
 		keyLen, h := getPbkdf2Params(alg)
-		key, err := pbkdf2.Key(h, string(ctx.key), salt, ctx.p2c, keyLen)
+		key, err := pbkdf2Key(h, string(ctx.key), salt, ctx.p2c, keyLen)
 		if err != nil {
 			return recipientInfo{}, nil
 		}
@@ -434,7 +433,7 @@ func (ctx *symmetricKeyCipher) decryptKey(headers rawHeader, recipient *recipien
 
 		// derive key
 		keyLen, h := getPbkdf2Params(alg)
-		key, err := pbkdf2.Key(h, string(ctx.key), salt, p2c, keyLen)
+		key, err := pbkdf2Key(h, string(ctx.key), salt, p2c, keyLen)
 		if err != nil {
 			return nil, err
 		}

--- a/symmetric_go124.go
+++ b/symmetric_go124.go
@@ -1,0 +1,28 @@
+//go:build go1.24
+
+/*-
+ * Copyright 2014 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"crypto/pbkdf2"
+	"hash"
+)
+
+func pbkdf2Key(h func() hash.Hash, password string, salt []byte, iter, keyLen int) ([]byte, error) {
+	return pbkdf2.Key(h, password, salt, iter, keyLen)
+}

--- a/symmetric_legacy.go
+++ b/symmetric_legacy.go
@@ -1,0 +1,29 @@
+//go:build !go1.24
+
+/*-
+ * Copyright 2014 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"hash"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+func pbkdf2Key(h func() hash.Hash, password string, salt []byte, iter, keyLen int) ([]byte, error) {
+	return pbkdf2.Key([]byte(password), salt, iter, keyLen, h), nil
+}

--- a/symmetric_test.go
+++ b/symmetric_test.go
@@ -19,7 +19,6 @@ package jose
 import (
 	"bytes"
 	"crypto/cipher"
-	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
 	"io"
@@ -181,7 +180,7 @@ func TestVectorPBES2_HS256A_128KW(t *testing.T) {
 		188, 66, 125, 36, 200, 222, 124, 5, 103, 249, 52, 117, 184, 140, 81,
 		246, 158, 161, 177, 20, 33, 245, 57, 59, 4}
 
-	derivedKey, err := pbkdf2.Key(sha256.New, string(cipher.key), salt, cipher.p2c, 16)
+	derivedKey, err := pbkdf2Key(sha256.New, string(cipher.key), salt, cipher.p2c, 16)
 	if err != nil {
 		t.Fatal("Unable to encrypt:", err)
 	}


### PR DESCRIPTION
- Uses a build tag to decide between stdlib pbkdf2 implementation or `x/` legacy implementation based on Go version
- Restores benchmarks to legacy syntax
- Sets go.mod minimum version to 1.23.0
  - Since Go 1.21, the `.0` should be added to indicate the minimum version of the toolchain AFAIK, notably it excludes prereleases https://tip.golang.org/doc/toolchain#version So I went with it instead of going to the previous `1.23`
- Restores 1.23 CI workflow