### PR TITLE
Remove dependency on testify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,4 @@ module github.com/go-jose/go-jose/v4
 
 go 1.23.0
 
-require (
-	github.com/stretchr/testify v1.10.0
-	golang.org/x/crypto v0.39.0
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
+require golang.org/x/crypto v0.39.0

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,2 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
 golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -34,8 +34,8 @@ import (
 
 	"github.com/go-jose/go-jose/v4/json"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/go-jose/go-jose/v4/testutils/assert"
+	"github.com/go-jose/go-jose/v4/testutils/require"
 )
 
 // Test chain of two X.509 certificates
@@ -397,7 +397,7 @@ func TestCertificatesURL(t *testing.T) {
    "x5u": "://example.com/keys.json"
 }`
 	err = jwk2.UnmarshalJSON([]byte(invalidURLJWK))
-	require.EqualError(t, err, "go-jose/go-jose: invalid JWK, x5u header is invalid URL: parse \"://example.com/keys.json\": missing protocol scheme")
+	require.Equal(t, err.Error(), "go-jose/go-jose: invalid JWK, x5u header is invalid URL: parse \"://example.com/keys.json\": missing protocol scheme")
 }
 
 func TestInvalidThumbprintsX509(t *testing.T) {

--- a/jws_test.go
+++ b/jws_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/go-jose/go-jose/v4/testutils/assert"
 )
 
 const trustedCA = `

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4/json"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/go-jose/go-jose/v4/testutils/assert"
 )
 
 func TestEncodeClaims(t *testing.T) {
@@ -72,7 +72,7 @@ func TestDecodeClaims(t *testing.T) {
 	if err := json.Unmarshal(s, &c); assert.NoError(t, err) {
 		assert.Equal(t, "issuer", c.Issuer)
 		assert.Equal(t, "subject", c.Subject)
-		assert.Equal(t, Audience{"a1", "a2"}, c.Audience)
+		assert.EqualSlice(t, Audience{"a1", "a2"}, c.Audience)
 		assert.True(t, now.Equal(c.IssuedAt.Time()))
 		assert.True(t, now.Add(1*time.Hour).Equal(c.Expiry.Time()))
 	}
@@ -80,7 +80,7 @@ func TestDecodeClaims(t *testing.T) {
 	s2 := []byte(`{"aud": "a1"}`)
 	c2 := Claims{}
 	if err := json.Unmarshal(s2, &c2); assert.NoError(t, err) {
-		assert.Equal(t, Audience{"a1"}, c2.Audience)
+		assert.EqualSlice(t, Audience{"a1"}, c2.Audience)
 	}
 
 	invalid := []struct {
@@ -107,7 +107,7 @@ func TestNumericDate(t *testing.T) {
 
 	nonZeroDate := NewNumericDate(time.Unix(0, 0))
 	expected := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	assert.Truef(t, expected.Equal(nonZeroDate.Time()), "Expected derived time to be %s", expected)
+	assert.True(t, expected.Equal(nonZeroDate.Time()), "Expected derived time to be %s", expected)
 }
 
 func TestEncodeClaimsTimeValues(t *testing.T) {

--- a/jwt/validation_test.go
+++ b/jwt/validation_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/go-jose/go-jose/v4/testutils/assert"
 )
 
 func TestFieldsMatch(t *testing.T) {

--- a/shared.go
+++ b/shared.go
@@ -17,11 +17,13 @@
 package jose
 
 import (
+	"bytes"
 	"crypto/elliptic"
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/go-jose/go-jose/v4/json"
 )
@@ -197,6 +199,70 @@ type Header struct {
 	//
 	// [json.Unmarshal]: https://pkg.go.dev/encoding/json#Unmarshal
 	ExtraHeaders map[HeaderKey]interface{}
+}
+
+// Equal compares a header struct with another header struct
+func (h1 Header) Equal(h2 any) bool {
+	h2Typed, ok := h2.(Header)
+	if !ok {
+		return false
+	}
+	if h1.KeyID != h2Typed.KeyID {
+		return false
+	}
+	if h1.JSONWebKey == nil && h2Typed.JSONWebKey != nil {
+		return false
+	}
+	if h1.JSONWebKey != nil && h2Typed.JSONWebKey == nil {
+		return false
+	}
+	if h1.JSONWebKey != nil && h2Typed.JSONWebKey != nil {
+		h1JSONWebKey, err := h1.JSONWebKey.MarshalJSON()
+		if err != nil {
+			return false
+		}
+		h2JSONWebKey, err := h2Typed.JSONWebKey.MarshalJSON()
+		if err != nil {
+			return false
+		}
+		if !bytes.Equal(h1JSONWebKey, h2JSONWebKey) {
+			return false
+		}
+	}
+	if h1.Algorithm != h2Typed.Algorithm {
+		return false
+	}
+	if h1.Nonce != h2Typed.Nonce {
+		return false
+	}
+	if !slices.EqualFunc(h1.certificates, h2Typed.certificates, func(v1, v2 *x509.Certificate) bool {
+		return bytes.Equal(v1.Raw, v2.Raw)
+	}) {
+		return false
+	}
+
+	if len(h1.ExtraHeaders) != len(h2Typed.ExtraHeaders) {
+		return false
+	}
+
+	for i := range h1.ExtraHeaders {
+		if _, ok := h2Typed.ExtraHeaders[i]; !ok {
+			return false
+		}
+		v1, err := json.Marshal(h1.ExtraHeaders[i])
+		if err != nil {
+			return false
+		}
+		v2, err := json.Marshal(h2Typed.ExtraHeaders[i])
+		if err != nil {
+			return false
+		}
+		if !bytes.Equal(v1, v2) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Certificates verifies & returns the certificate chain present

--- a/shared_test.go
+++ b/shared_test.go
@@ -1,0 +1,37 @@
+package jose
+
+import "testing"
+
+func TestHeaderEqual(t *testing.T) {
+	header1 := Header{
+		KeyID:        "1-2-3-4",
+		Algorithm:    "test",
+		ExtraHeaders: map[HeaderKey]interface{}{"kid": "1-2-3-4"},
+	}
+	header2 := Header{
+		KeyID:        "1-2-3-4",
+		Algorithm:    "test",
+		ExtraHeaders: map[HeaderKey]interface{}{"kid": "1-2-3-4"},
+	}
+	ok := header1.Equal(header2)
+	if !ok {
+		t.Fatalf("neader1 and header2 are not equal, expected equal")
+	}
+}
+
+func TestHeaderNotEqual(t *testing.T) {
+	header1 := Header{
+		KeyID:        "1-2-3-4",
+		Algorithm:    "test",
+		ExtraHeaders: map[HeaderKey]interface{}{"kid": "1-2-3-4"},
+	}
+	header2 := Header{
+		KeyID:        "1-2-3-4",
+		Algorithm:    "test",
+		ExtraHeaders: map[HeaderKey]interface{}{"kid": "9-9-9-9"},
+	}
+	ok := header1.Equal(header2)
+	if ok {
+		t.Fatalf("neader1 and header2 are equal, expected not equal")
+	}
+}

--- a/testutils/assert/equal.go
+++ b/testutils/assert/equal.go
@@ -1,0 +1,129 @@
+package assert
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+)
+
+type TInterface interface {
+	Errorf(format string, args ...any)
+	Helper()
+}
+
+func Equal[T comparable](t TInterface, actual, expected T) bool {
+	t.Helper()
+	if expected != actual {
+		t.Errorf("expected '%+v', but actual value is '%+v'", expected, actual)
+		return false
+	}
+	return true
+}
+
+func EqualSlice[T comparable](t TInterface, actual, expected []T) bool {
+	t.Helper()
+	if !slices.Equal(expected, actual) {
+		t.Errorf("expected slice (%+v) is not equal to actual slice (%+v)", expected, actual)
+		return false
+	}
+	return true
+}
+
+func EqualJSON[K comparable, V comparable](t TInterface, actual, expected map[K]V) bool {
+	t.Helper()
+	if len(expected) != len(actual) {
+		t.Errorf("length mismatch: expected %d, got %d", len(expected), len(actual))
+		return false
+	}
+
+	for i := range expected {
+		if _, ok := actual[i]; !ok {
+			t.Errorf("expected map's keys (%+v) don't match actual map's keys (%+v)", expected, actual)
+		}
+		v1, err1 := json.Marshal(expected[i])
+		v2, err2 := json.Marshal(actual[i])
+		if err1 != nil || err2 != nil || !bytes.Equal(v1, v2) {
+			t.Errorf("expected slice (%+v) is not equal to actual slice (%+v)", expected, actual)
+			return false
+		}
+	}
+	return true
+}
+
+func True(t TInterface, actual bool, errMsg ...any) bool {
+	t.Helper()
+	if !actual {
+		t.Errorf("expected true. Got: %v%s", actual, getMsgParameter(errMsg))
+		return false
+	}
+	return true
+}
+
+func NotNil(t TInterface, actual any) bool {
+	t.Helper()
+	if actual == nil {
+		t.Errorf("expected not nil, got %+v", actual)
+		return false
+	}
+	return true
+}
+
+func Nil(t TInterface, actual any) bool {
+	t.Helper()
+	if actual != nil {
+		t.Errorf("expected nil, got %+v", actual)
+		return false
+	}
+	return true
+}
+
+func NoError(t TInterface, err error, errMsg ...any) bool {
+	t.Helper()
+	if err != nil {
+		t.Errorf("expected no error. Got error: %s%s", err, getMsgParameter(errMsg))
+		return false
+	}
+	return true
+}
+
+func Error(t TInterface, err error, errMsg ...any) bool {
+	t.Helper()
+	if err == nil {
+		t.Errorf("expected no error. Got error: %s%s", err, getMsgParameter(errMsg))
+		return false
+	}
+	return true
+}
+
+func ErrorIs(t TInterface, actual, expected error) bool {
+	t.Helper()
+	if !errors.Is(actual, expected) {
+		t.Errorf("expected error %s, got %s", expected, actual)
+		return false
+	}
+	return true
+}
+
+func Len[T comparable](t TInterface, expected []T, length int) bool {
+	t.Helper()
+	if len(expected) != length {
+		t.Errorf("expected length %d, got %d", length, len(expected))
+		return false
+	}
+	return true
+}
+
+func getMsgParameter(errMsg ...any) string {
+	if len(errMsg) > 0 {
+		msg := errMsg[0]
+		errMsgString, ok := msg.(string)
+		if ok && len(errMsg) > 1 {
+			return ". Message: " + fmt.Sprintf(errMsgString, errMsg[1:]...)
+		} else {
+			return ". Message: " + errMsgString
+		}
+	}
+	return ""
+}

--- a/testutils/assert/equal_test.go
+++ b/testutils/assert/equal_test.go
@@ -1,0 +1,177 @@
+package assert
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type mockT struct {
+	errors []string
+	failed bool
+}
+
+func (m *mockT) Errorf(format string, args ...any) {
+	m.errors = append(m.errors, fmt.Sprintf(format, args...))
+	m.failed = true
+}
+func (m *mockT) Helper() {
+
+}
+func TestEqual(t *testing.T) {
+	m := &mockT{}
+	if !Equal(m, "one", "one") {
+		t.Fatalf("expected equal")
+	}
+	m.failed = false
+	m.errors = []string{}
+	if Equal(m, "one", "two") {
+		if !m.failed {
+			t.Fatalf("test didn't fail. Expected test to have failed = true")
+		}
+	}
+}
+
+func TestEqualSlice(t *testing.T) {
+	m := &mockT{}
+	if !EqualSlice(m, []string{"one", "two"}, []string{"one", "two"}) {
+		t.Fatalf("expected equal")
+	}
+	m.failed = false
+	m.errors = []string{}
+	if EqualSlice(m, []string{"one", "two"}, []string{"one", "three"}) {
+		if !m.failed {
+			t.Fatalf("test didn't fail. Expected test to have failed = true")
+		}
+	}
+}
+
+func TestJSON(t *testing.T) {
+	m := &mockT{}
+	if !EqualJSON(m, map[string]string{"one": "two"}, map[string]string{"one": "two"}) {
+		t.Fatalf("expected equal")
+	}
+	m.failed = false
+	m.errors = []string{}
+	if EqualJSON(m, map[string]string{"one": "two"}, map[string]string{"one": "three"}) {
+		if !m.failed {
+			t.Fatalf("test didn't fail. Expected test to have failed = true")
+		}
+	}
+	m.failed = false
+	m.errors = []string{}
+	if EqualJSON(m, map[string]string{"one": "two"}, map[string]string{"two": "three"}) {
+		if !m.failed {
+			t.Fatalf("test didn't fail. Expected test to have failed = true")
+		}
+	}
+}
+
+func TestTrue(t *testing.T) {
+	m := &mockT{}
+	if !True(m, true) {
+		t.Fatalf("expected equal")
+	}
+	m.failed = false
+	m.errors = []string{}
+	if True(m, false) {
+		if !m.failed {
+			t.Fatalf("test didn't fail. Expected test to have failed = true")
+		}
+	}
+}
+
+func TestNil(t *testing.T) {
+	m := &mockT{}
+	if !Nil(m, nil) {
+		t.Fatalf("expected nil")
+	}
+	m.failed = false
+	m.errors = []string{}
+	if Nil(m, "string") {
+		if !m.failed {
+			t.Fatalf("test didn't fail. Expected test to have failed = true")
+		}
+	}
+}
+
+func TestNoError(t *testing.T) {
+	m := &mockT{}
+	if !NoError(m, nil) {
+		t.Fatalf("expected no error")
+	}
+	m.failed = false
+	m.errors = []string{}
+	if NoError(m, errors.New("error")) {
+		if !m.failed {
+			t.Fatalf("test didn't fail. Expected test to have failed = true")
+		}
+	}
+}
+
+func TestNotNil(t *testing.T) {
+	m := &mockT{}
+	if !NotNil(m, "string") {
+		t.Fatalf("expected not nil")
+	}
+	m.failed = false
+	m.errors = []string{}
+	if NotNil(m, nil) {
+		if !m.failed {
+			t.Fatalf("test didn't fail. Expected test to have failed = true")
+		}
+	}
+}
+
+func TestError(t *testing.T) {
+	m := &mockT{}
+	if !Error(m, errors.New("error")) {
+		t.Fatalf("expected error")
+	}
+	m.failed = false
+	m.errors = []string{}
+	if Error(m, nil) {
+		if !m.failed {
+			t.Fatalf("test didn't fail. Expected test to have failed = true")
+		}
+	}
+}
+
+func TestErrorIs(t *testing.T) {
+	m := &mockT{}
+
+	var ErrNotFound = errors.New("not found")
+	if !ErrorIs(m, ErrNotFound, ErrNotFound) {
+		t.Fatalf("expected error not found")
+	}
+	m.failed = false
+	m.errors = []string{}
+	if ErrorIs(m, errors.New("another error"), ErrNotFound) {
+		if !m.failed {
+			t.Fatalf("test didn't fail. Expected test to have failed = true")
+		}
+	}
+}
+
+func TestLen(t *testing.T) {
+	m := &mockT{}
+
+	if !Len(m, []int{1, 1, 1, 1}, 4) {
+		t.Fatalf("expected len 4")
+	}
+	m.failed = false
+	m.errors = []string{}
+	if Len(m, []int{1, 1, 1, 1}, 5) {
+		if !m.failed {
+			t.Fatalf("test didn't fail. Expected test to have failed = true")
+		}
+	}
+}
+
+func TestGetMsgParameter(t *testing.T) {
+	message := getMsgParameter("this is the %s", "message")
+	expected := ". Message: this is the message"
+	if message != expected {
+		t.Fatalf("got %s, expected %s", message, expected)
+	}
+}

--- a/testutils/assert/equalfunc.go
+++ b/testutils/assert/equalfunc.go
@@ -1,0 +1,35 @@
+package assert
+
+type EqualCapability interface {
+	Equal(any) bool
+}
+
+func EqualSliceFunc[T any](t TInterface, expected, actual []T) bool {
+	t.Helper()
+	if len(expected) != len(actual) {
+		t.Errorf("slice are not of equal lengths")
+	}
+	for i := range actual {
+		v1Typed, ok := any(actual[i]).(EqualCapability)
+		if !ok {
+			t.Errorf("actual value slice element doesn't contain Equal(any) function")
+		}
+		v2Typed, ok := any(expected[i]).(EqualCapability)
+		if !ok {
+			t.Errorf("expected value slice element doesn't contain Equal(any) function")
+		}
+		if !v2Typed.Equal(v1Typed) {
+			t.Errorf("expected slice (%+v) is not equal to actual slice (%+v)", actual, expected)
+		}
+	}
+
+	return true
+}
+
+func EqualFunc(t TInterface, expected, actual EqualCapability) bool {
+	t.Helper()
+	if !expected.Equal(actual) {
+		t.Errorf("expected (%+v) is not equal to actual (%+v)", expected, actual)
+	}
+	return true
+}

--- a/testutils/assert/equalfunc_test.go
+++ b/testutils/assert/equalfunc_test.go
@@ -1,0 +1,26 @@
+package assert
+
+import "testing"
+
+type TestStruct1 struct {
+	A string
+	B int
+}
+
+func (ts1 TestStruct1) Equal(ts2 any) bool {
+	return ts1.A == ts2.(TestStruct1).A && ts1.B == ts2.(TestStruct1).B
+}
+
+func TestEqualSliceFunc(t *testing.T) {
+	m := &mockT{}
+	if !EqualSliceFunc(m, []TestStruct1{{A: "test", B: 1}}, []TestStruct1{{A: "test", B: 1}}) {
+		t.Fatalf("equal slice func not equal. Expected equal")
+	}
+}
+
+func TestEqualFunc(t *testing.T) {
+	m := &mockT{}
+	if !EqualFunc(m, TestStruct1{A: "test", B: 1}, TestStruct1{A: "test", B: 1}) {
+		t.Fatalf("equal slice func not equal. Expected equal")
+	}
+}

--- a/testutils/require/equal.go
+++ b/testutils/require/equal.go
@@ -1,0 +1,25 @@
+package require
+
+import (
+	"github.com/go-jose/go-jose/v4/testutils/assert"
+)
+
+type TInterface interface {
+	Errorf(format string, args ...any)
+	Helper()
+	FailNow()
+}
+
+func NoError(t TInterface, err error, errMsg ...any) {
+	t.Helper()
+	if !assert.NoError(t, err, errMsg...) {
+		t.FailNow()
+	}
+}
+
+func Equal[T comparable](t TInterface, actual, expected T) {
+	t.Helper()
+	if !assert.Equal(t, actual, expected) {
+		t.FailNow()
+	}
+}

--- a/testutils/require/equal_test.go
+++ b/testutils/require/equal_test.go
@@ -1,0 +1,54 @@
+package require
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type mockT struct {
+	errors  []string
+	failed  bool
+	failnow bool
+}
+
+func (m *mockT) Errorf(format string, args ...any) {
+	m.errors = append(m.errors, fmt.Sprintf(format, args...))
+	m.failed = true
+}
+func (m *mockT) Helper() {
+
+}
+
+func (m *mockT) FailNow() {
+	m.failnow = true
+}
+func TestEqual(t *testing.T) {
+	m := &mockT{}
+	Equal(m, "one", "one")
+	if m.failnow {
+		t.Fatalf("expected equal")
+	}
+	m.failed = false
+	m.failnow = false
+	m.errors = []string{}
+	Equal(m, "one", "two")
+	if !m.failnow {
+		t.Fatalf("test didn't fail. Expected test to have failnow = true")
+	}
+}
+
+func TestNoError(t *testing.T) {
+	m := &mockT{}
+	NoError(m, nil)
+	if m.failnow {
+		t.Fatalf("expected no error")
+	}
+	m.failed = false
+	m.failnow = false
+	m.errors = []string{}
+	NoError(m, errors.New("error"))
+	if !m.failnow {
+		t.Fatalf("test didn't fail. Expected test to have failnow = true")
+	}
+}


### PR DESCRIPTION
This PR removes the dependency on testify. Unit tests of the new code are included.

**Why remove testify:**

- testify is a dependency (and has indirect dependencies)
- testify uses go-spew which is not maintained anymore (see https://github.com/stretchr/testify/issues/1638)
- go-spew is in a 'not allowed' list in Kubernetes (see https://github.com/kubernetes/kubernetes/issues/103942) and therefore kubernetes can't use go-jose v4 (see https://github.com/kubernetes/kubernetes/issues/123252)
- Equal was used to compare complex structs, but Equal in testify doesn't fully compare values, see https://github.com/stretchr/testify/issues/1616
- removing testify would remove the dependencies on external projects, reducing operational risk, as go-jose has a lot of users

