### PR TITLE
Add JSONWebKey type to makeJWERecipient

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -286,6 +286,10 @@ func makeJWERecipient(alg KeyAlgorithm, encryptionKey interface{}) (recipientKey
 		return newSymmetricRecipient(alg, encryptionKey)
 	case string:
 		return newSymmetricRecipient(alg, []byte(encryptionKey))
+	case JSONWebKey:
+		recipient, err := makeJWERecipient(alg, encryptionKey.Key)
+		recipient.keyID = encryptionKey.KeyID
+		return recipient, err
 	case *JSONWebKey:
 		recipient, err := makeJWERecipient(alg, encryptionKey.Key)
 		recipient.keyID = encryptionKey.KeyID

--- a/crypter_test.go
+++ b/crypter_test.go
@@ -255,7 +255,7 @@ func TestRoundtripsJWECorrupted(t *testing.T) {
 	}
 }
 
-func TestEncrypterWithJWKAndKeyID(t *testing.T) {
+func TestEncrypterWithJWKAndKeyIDByReference(t *testing.T) {
 	enc, err := NewEncrypter(A128GCM, Recipient{Algorithm: A128KW, Key: &JSONWebKey{
 		KeyID: "test-id",
 		Key:   []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
@@ -277,6 +277,31 @@ func TestEncrypterWithJWKAndKeyID(t *testing.T) {
 	}
 	if parsed2.Header.KeyID != "test-id" {
 		t.Errorf("expected message to have key id from JWK, but found '%s' instead", parsed2.Header.KeyID)
+	}
+}
+
+func TestEncrypterWithJWKAndKeyIDByValue(t *testing.T) {
+	enc, err := NewEncrypter(A128GCM, Recipient{Algorithm: A128KW, Key: JSONWebKey{
+		KeyID: "test-id-value",
+		Key:   []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+	}}, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ciphertext, _ := enc.Encrypt([]byte("Lorem ipsum dolor sit amet"))
+
+	serialized1, _ := ciphertext.CompactSerialize()
+	serialized2 := ciphertext.FullSerialize()
+
+	parsed1, _ := ParseEncrypted(serialized1, []KeyAlgorithm{A128KW}, []ContentEncryption{A128GCM})
+	parsed2, _ := ParseEncrypted(serialized2, []KeyAlgorithm{A128KW}, []ContentEncryption{A128GCM})
+
+	if parsed1.Header.KeyID != "test-id-value" {
+		t.Errorf("expected message to have key id from JWK by value, but found '%s' instead", parsed1.Header.KeyID)
+	}
+	if parsed2.Header.KeyID != "test-id-value" {
+		t.Errorf("expected message to have key id from JWK by value, but found '%s' instead", parsed2.Header.KeyID)
 	}
 }
 


### PR DESCRIPTION
This PR fixes an issue where JSONWebKey is marked as a valid type in Recipient: 
```
type Recipient struct {
	Algorithm KeyAlgorithm
	// Key must have one of these types:
	//  - ed25519.PublicKey
	//  - *ecdsa.PublicKey
	//  - *rsa.PublicKey
	//  - *JSONWebKey
	//  - JSONWebKey
	//  - []byte (a symmetric key)
	//  - Any type that satisfies the OpaqueKeyEncrypter interface
	//
	// The type of Key must match the value of Algorithm.
	Key        interface{}
	KeyID      string
	PBES2Count int
	PBES2Salt  []byte
}
```
But is rejected further down the line when calling `makeJWERecipient()`.

I've also added tests and edited the name to show the difference in between the two types. 
Thanks!
