### PR TITLE
testutils/assert: remove True, Nil, NotNil

### DIFF
--- a/jwk_test.go
+++ b/jwk_test.go
@@ -836,9 +836,9 @@ func TestEd25519Serialization(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.True(t, bytes.Equal(
-		[]byte(jwk.Key.(ed25519.PrivateKey).Public().(ed25519.PublicKey)),
-		[]byte(jwk2.Key.(ed25519.PrivateKey).Public().(ed25519.PublicKey))))
+	assert.EqualSlice(t,
+		jwk.Key.(ed25519.PrivateKey).Public().(ed25519.PublicKey),
+		jwk2.Key.(ed25519.PrivateKey).Public().(ed25519.PublicKey))
 }
 
 type fakeOpaqueSigner struct {

--- a/jws_test.go
+++ b/jws_test.go
@@ -697,7 +697,9 @@ func TestJWSComputeAuthDataBase64(t *testing.T) {
 		},
 	})
 	// Invalid header, should return error
-	assert.NotNil(t, err)
+	if err == nil {
+		t.Errorf("expected error when computing auth data for invalid signature")
+	}
 
 	payload := []byte{0x01}
 	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
@@ -710,7 +712,8 @@ func TestJWSComputeAuthDataBase64(t *testing.T) {
 			Protected: b64TrueHeader,
 		},
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err, "computing auth data for \"b64\": true")
+
 	// Payload should be b64 encoded
 	assert.Len(t, data, len(b64TrueHeader.base64())+len(encodedPayload)+1)
 
@@ -719,7 +722,7 @@ func TestJWSComputeAuthDataBase64(t *testing.T) {
 			Protected: b64FalseHeader,
 		},
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err, "computing auth data for \"b64\": false")
 	// Payload should *not* be b64 encoded
 	assert.Len(t, data, len(b64FalseHeader.base64())+len(payload)+1)
 }

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -73,8 +73,12 @@ func TestDecodeClaims(t *testing.T) {
 		assert.Equal(t, "issuer", c.Issuer)
 		assert.Equal(t, "subject", c.Subject)
 		assert.EqualSlice(t, Audience{"a1", "a2"}, c.Audience)
-		assert.True(t, now.Equal(c.IssuedAt.Time()))
-		assert.True(t, now.Add(1*time.Hour).Equal(c.Expiry.Time()))
+		if !now.Equal(c.IssuedAt.Time()) {
+			t.Errorf("IssuedAt = %s, want %s", c.IssuedAt.Time(), now)
+		}
+		if !now.Add(1 * time.Hour).Equal(c.Expiry.Time()) {
+			t.Errorf("Expiry = %s, want %s", c.Expiry.Time(), now.Add(1*time.Hour))
+		}
 	}
 
 	s2 := []byte(`{"aud": "a1"}`)
@@ -100,14 +104,20 @@ func TestDecodeClaims(t *testing.T) {
 
 func TestNumericDate(t *testing.T) {
 	zeroDate := NewNumericDate(time.Time{})
-	assert.True(t, time.Time{}.Equal(zeroDate.Time()), "Expected derived time to be time.Time{}")
+	if !zeroDate.Time().Equal(time.Time{}) {
+		t.Errorf("zeroDate.Time() = %s, want %s", zeroDate.Time(), time.Time{})
+	}
 
 	zeroDate2 := (*NumericDate)(nil)
-	assert.True(t, time.Time{}.Equal(zeroDate2.Time()), "Expected derived time to be time.Time{}")
+	if !zeroDate2.Time().Equal(time.Time{}) {
+		t.Errorf("zeroDate2.Time() = %s, want %s", zeroDate2.Time(), time.Time{})
+	}
 
 	nonZeroDate := NewNumericDate(time.Unix(0, 0))
 	expected := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	assert.True(t, expected.Equal(nonZeroDate.Time()), "Expected derived time to be %s", expected)
+	if !nonZeroDate.Time().Equal(expected) {
+		t.Errorf("nonZeroDate.Time() = %s, want %s", nonZeroDate.Time(), expected)
+	}
 }
 
 func TestEncodeClaimsTimeValues(t *testing.T) {
@@ -127,8 +137,14 @@ func TestEncodeClaimsTimeValues(t *testing.T) {
 
 	c2 := Claims{}
 	if err := json.Unmarshal(b, &c2); assert.NoError(t, err) {
-		assert.True(t, c.NotBefore.Time().Equal(c2.NotBefore.Time()))
-		assert.True(t, c.IssuedAt.Time().Equal(c2.IssuedAt.Time()))
-		assert.True(t, c.Expiry.Time().Equal(c2.Expiry.Time()))
+		if !c.NotBefore.Time().Equal(c2.NotBefore.Time()) {
+			t.Errorf("c2.NotBefore = %s, want %s", c2.NotBefore.Time(), c.NotBefore.Time())
+		}
+		if !c.IssuedAt.Time().Equal(c2.IssuedAt.Time()) {
+			t.Errorf("c2.IssuedAt = %s, want %s", c2.IssuedAt.Time(), c.IssuedAt.Time())
+		}
+		if !c.Expiry.Time().Equal(c2.Expiry.Time()) {
+			t.Errorf("c2.Expiry = %s, want %s", c2.Expiry.Time(), c.Expiry.Time())
+		}
 	}
 }

--- a/testutils/assert/equal.go
+++ b/testutils/assert/equal.go
@@ -53,33 +53,6 @@ func EqualJSON[K comparable, V comparable](t TInterface, actual, expected map[K]
 	return true
 }
 
-func True(t TInterface, actual bool, errMsg ...any) bool {
-	t.Helper()
-	if !actual {
-		t.Errorf("expected true. Got: %v%s", actual, getMsgParameter(errMsg))
-		return false
-	}
-	return true
-}
-
-func NotNil(t TInterface, actual any) bool {
-	t.Helper()
-	if actual == nil {
-		t.Errorf("expected not nil, got %+v", actual)
-		return false
-	}
-	return true
-}
-
-func Nil(t TInterface, actual any) bool {
-	t.Helper()
-	if actual != nil {
-		t.Errorf("expected nil, got %+v", actual)
-		return false
-	}
-	return true
-}
-
 func NoError(t TInterface, err error, errMsg ...any) bool {
 	t.Helper()
 	if err != nil {

--- a/testutils/assert/equal_test.go
+++ b/testutils/assert/equal_test.go
@@ -67,34 +67,6 @@ func TestJSON(t *testing.T) {
 	}
 }
 
-func TestTrue(t *testing.T) {
-	m := &mockT{}
-	if !True(m, true) {
-		t.Fatalf("expected equal")
-	}
-	m.failed = false
-	m.errors = []string{}
-	if True(m, false) {
-		if !m.failed {
-			t.Fatalf("test didn't fail. Expected test to have failed = true")
-		}
-	}
-}
-
-func TestNil(t *testing.T) {
-	m := &mockT{}
-	if !Nil(m, nil) {
-		t.Fatalf("expected nil")
-	}
-	m.failed = false
-	m.errors = []string{}
-	if Nil(m, "string") {
-		if !m.failed {
-			t.Fatalf("test didn't fail. Expected test to have failed = true")
-		}
-	}
-}
-
 func TestNoError(t *testing.T) {
 	m := &mockT{}
 	if !NoError(m, nil) {
@@ -103,20 +75,6 @@ func TestNoError(t *testing.T) {
 	m.failed = false
 	m.errors = []string{}
 	if NoError(m, errors.New("error")) {
-		if !m.failed {
-			t.Fatalf("test didn't fail. Expected test to have failed = true")
-		}
-	}
-}
-
-func TestNotNil(t *testing.T) {
-	m := &mockT{}
-	if !NotNil(m, "string") {
-		t.Fatalf("expected not nil")
-	}
-	m.failed = false
-	m.errors = []string{}
-	if NotNil(m, nil) {
 		if !m.failed {
 			t.Fatalf("test didn't fail. Expected test to have failed = true")
 		}


### PR DESCRIPTION
These functions were used few places, and could generally be replaced with a simple `if` and a more informative error message, or a more specific assert function.

Follow up to #197 