### PR TITLE
Update CI to run on Go 1.24 and 1.25

### DIFF
--- a/.github/workflows/cram.yml
+++ b/.github/workflows/cram.yml
@@ -1,8 +1,9 @@
 name: Cram testing jose-util
 on:
   push:
-    branches: [ v3, main ]
-  pull_request: {}
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
 
 jobs:
   cram:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ v3, main ]
+    branches: [ '**' ]
   pull_request:
-    branches: [ v3, main ]
+    branches: [ '**' ]
 
 jobs:
   build:
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.23.x"
           - "1.24.x"
+          - "1.25.x"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
       matrix:
         GO_VERSION:
           # We only need to test vulns on one version
-          - "1.24.x"
+          - "1.25.x"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This also makes the branch selection the same for everything - just '**'.