### PR TITLE
Reject JWS with an unprotected critical b64 header

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -454,13 +454,9 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 		return nil, errors.New("go-jose/go-jose: too many recipients in payload; expecting only one")
 	}
 
-	critical, err := headers.getCritical()
+	err := headers.checkSupportedCritical(nil)
 	if err != nil {
-		return nil, fmt.Errorf("go-jose/go-jose: invalid crit header")
-	}
-
-	if len(critical) > 0 {
-		return nil, fmt.Errorf("go-jose/go-jose: unsupported crit header")
+		return nil, err
 	}
 
 	key, err := tryJWKS(decryptionKey, obj.Header)
@@ -527,13 +523,9 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Header, []byte, error) {
 	globalHeaders := obj.mergedHeaders(nil)
 
-	critical, err := globalHeaders.getCritical()
+	err := globalHeaders.checkSupportedCritical(nil)
 	if err != nil {
-		return -1, Header{}, nil, fmt.Errorf("go-jose/go-jose: invalid crit header")
-	}
-
-	if len(critical) > 0 {
-		return -1, Header{}, nil, fmt.Errorf("go-jose/go-jose: unsupported crit header")
+		return -1, Header{}, nil, err
 	}
 
 	key, err := tryJWKS(decryptionKey, obj.Header)

--- a/crypter.go
+++ b/crypter.go
@@ -454,7 +454,7 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 		return nil, errors.New("go-jose/go-jose: too many recipients in payload; expecting only one")
 	}
 
-	err := headers.checkSupportedCritical(nil)
+	err := headers.checkNoCritical()
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +523,7 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Header, []byte, error) {
 	globalHeaders := obj.mergedHeaders(nil)
 
-	err := globalHeaders.checkSupportedCritical(nil)
+	err := globalHeaders.checkNoCritical()
 	if err != nil {
 		return -1, Header{}, nil, err
 	}

--- a/shared.go
+++ b/shared.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+
 	"github.com/go-jose/go-jose/v4/json"
 )
 
@@ -76,6 +77,9 @@ var (
 
 	// ErrUnsupportedEllipticCurve indicates unsupported or unknown elliptic curve has been found.
 	ErrUnsupportedEllipticCurve = errors.New("go-jose/go-jose: unsupported/unknown elliptic curve")
+
+	// ErrUnsupportedCriticalHeader is returned when a header is marked critical but not supported by go-jose.
+	ErrUnsupportedCriticalHeader = errors.New("go-jose/go-jose: unsupported critical header")
 )
 
 // Key management algorithms
@@ -166,8 +170,8 @@ const (
 )
 
 // supportedCritical is the set of supported extensions that are understood and processed.
-var supportedCritical = map[string]bool{
-	headerB64: true,
+var supportedCritical = map[string]struct{}{
+	headerB64: {},
 }
 
 // rawHeader represents the JOSE header for JWE/JWS objects (used for parsing).
@@ -343,6 +347,23 @@ func (parsed rawHeader) getCritical() ([]string, error) {
 		return nil, err
 	}
 	return q, nil
+}
+
+// checkSupportedCritical verifies there are no unsupported critical headers.
+// Supported headers are passed in as a set: map of names to empty structs
+func (parsed rawHeader) checkSupportedCritical(supported map[string]struct{}) error {
+	crit, err := parsed.getCritical()
+	if err != nil {
+		return err
+	}
+
+	for _, name := range crit {
+		if _, ok := supported[name]; !ok {
+			return ErrUnsupportedCriticalHeader
+		}
+	}
+
+	return nil
 }
 
 // getS2C extracts parsed "p2c" from the raw JSON.

--- a/shared.go
+++ b/shared.go
@@ -349,6 +349,15 @@ func (parsed rawHeader) getCritical() ([]string, error) {
 	return q, nil
 }
 
+// checkNoCritical verifies there are no critical headers present.
+func (parsed rawHeader) checkNoCritical() error {
+	if _, ok := parsed[headerCritical]; ok {
+		return ErrUnsupportedCriticalHeader
+	}
+
+	return nil
+}
+
 // checkSupportedCritical verifies there are no unsupported critical headers.
 // Supported headers are passed in as a set: map of names to empty structs
 func (parsed rawHeader) checkSupportedCritical(supported map[string]struct{}) error {

--- a/signing.go
+++ b/signing.go
@@ -406,8 +406,12 @@ func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey inter
 	signature := obj.Signatures[0]
 
 	if signature.header != nil {
-		// No unsupported headers should be present in the unprotected header
-		err = signature.header.checkSupportedCritical(nil)
+		// Per https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.11,
+		// 4.1.11. "crit" (Critical) Header Parameter
+		// "When used, this Header Parameter MUST be integrity
+		// protected; therefore, it MUST occur only within the JWS
+		// Protected Header.
+		err = signature.header.checkNoCritical()
 		if err != nil {
 			return err
 		}
@@ -475,8 +479,12 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 outer:
 	for i, signature := range obj.Signatures {
 		if signature.header != nil {
-			// No unsupported headers should be present in the unprotected header
-			err = signature.header.checkSupportedCritical(nil)
+			// Per https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.11,
+			// 4.1.11. "crit" (Critical) Header Parameter
+			// "When used, this Header Parameter MUST be integrity
+			// protected; therefore, it MUST occur only within the JWS
+			// Protected Header.
+			err = signature.header.checkNoCritical()
 			if err != nil {
 				continue outer
 			}

--- a/signing.go
+++ b/signing.go
@@ -483,7 +483,7 @@ outer:
 			// 4.1.11. "crit" (Critical) Header Parameter
 			// "When used, this Header Parameter MUST be integrity
 			// protected; therefore, it MUST occur only within the JWS
-			// Protected Header.
+			// Protected Header."
 			err = signature.header.checkNoCritical()
 			if err != nil {
 				continue outer

--- a/signing.go
+++ b/signing.go
@@ -410,7 +410,7 @@ func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey inter
 		// 4.1.11. "crit" (Critical) Header Parameter
 		// "When used, this Header Parameter MUST be integrity
 		// protected; therefore, it MUST occur only within the JWS
-		// Protected Header.
+		// Protected Header."
 		err = signature.header.checkNoCritical()
 		if err != nil {
 			return err

--- a/signing_test.go
+++ b/signing_test.go
@@ -353,7 +353,20 @@ func TestInvalidJWS(t *testing.T) {
 	}
 	obj.Signatures[0].header = &rawHeader{}
 
-	if err = obj.Signatures[0].header.set(headerCritical, []string{"TEST"}); err != nil {
+	// headerB64 is known, but should be in protected
+	if err = obj.Signatures[0].header.set(headerCritical, []string{headerB64}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = obj.Verify(&rsaTestKey.PublicKey)
+	if err == nil {
+		t.Error("should not verify message with an unprotected but known crit header")
+	}
+
+	// reject unknown critical headers
+	obj.Signatures[0].protected = &rawHeader{}
+	obj.Signatures[0].header = &rawHeader{}
+	if err = obj.Signatures[0].protected.set(headerCritical, []string{"unknown-critical-header"}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
The only critical header that go-jose supports is b64 from RFC7797.

go-jose correctly only respects that header if it appears in a protected header. go-jose correctly rejects unknown critical headers.

However, go-jose does not reject a JWS which contains a critical b64 unprotected header.

I don't believe this has any security impact, as the only place this is exposed is via the Signature header members which expose unprotected headers, and so a library user is already aware they are not to be trusted. The 'critical' behavior (of not base64-encoding the value, defined in RFC7797) is not influenced here.

Return a new ErrUnsupportedCriticalHeader error exported as a constant.

Reported by: Muhammad Noman Ilyas @AL-Cybision