### PR TITLE
Fix RFC 7797 “b64” handling: support unencoded payloads and add DetachedFullSerialize()

### DIFF
--- a/jws.go
+++ b/jws.go
@@ -28,7 +28,7 @@ import (
 
 // rawJSONWebSignature represents a raw JWS JSON object. Used for parsing/serializing.
 type rawJSONWebSignature struct {
-	Payload    *byteBuffer        `json:"payload,omitempty"`
+	Payload    string             `json:"payload,omitempty"`
 	Signatures []rawSignatureInfo `json:"signatures,omitempty"`
 	Protected  *byteBuffer        `json:"protected,omitempty"`
 	Header     *rawHeader         `json:"header,omitempty"`
@@ -192,7 +192,7 @@ func ParseSignedJSON(
 		return nil, err
 	}
 
-	return parsed.sanitized(signatureAlgorithms)
+	return parsed.sanitized(signatureAlgorithms, false)
 }
 
 func containsSignatureAlgorithm(haystack []SignatureAlgorithm, needle SignatureAlgorithm) bool {
@@ -224,20 +224,19 @@ func newErrUnexpectedSignatureAlgorithm(got SignatureAlgorithm, expected []Signa
 }
 
 // sanitized produces a cleaned-up JWS object from the raw JSON.
-func (parsed *rawJSONWebSignature) sanitized(signatureAlgorithms []SignatureAlgorithm) (*JSONWebSignature, error) {
+func (parsed *rawJSONWebSignature) sanitized(signatureAlgorithms []SignatureAlgorithm, detached bool) (*JSONWebSignature, error) {
 	if len(signatureAlgorithms) == 0 {
 		return nil, errors.New("go-jose/go-jose: no signature algorithms specified")
 	}
-	if parsed.Payload == nil {
-		return nil, fmt.Errorf("go-jose/go-jose: missing payload in JWS message")
-	}
 
 	obj := &JSONWebSignature{
-		payload:    parsed.Payload.bytes(),
 		Signatures: make([]Signature, len(parsed.Signatures)),
 	}
 
+	// RFC 7797 JWS Unencoded Payload Option
+	needsBase64 := true
 	if len(parsed.Signatures) == 0 {
+
 		// No signatures array, must be flattened serialization
 		signature := Signature{}
 		if parsed.Protected != nil && len(parsed.Protected.bytes()) > 0 {
@@ -245,6 +244,10 @@ func (parsed *rawJSONWebSignature) sanitized(signatureAlgorithms []SignatureAlgo
 			err := json.Unmarshal(parsed.Protected.bytes(), signature.protected)
 			if err != nil {
 				return nil, err
+			}
+			// RFC 7797 JWS Unencoded Payload Option
+			if b, err := signature.protected.getB64(); err == nil {
+				needsBase64 = b
 			}
 		}
 
@@ -354,8 +357,27 @@ func (parsed *rawJSONWebSignature) sanitized(signatureAlgorithms []SignatureAlgo
 		// Copy value of sig
 		original := sig
 
+		// RFC 7797 JWS Unencoded Payload Option
+		if b, err := obj.Signatures[i].protected.getB64(); err == nil {
+			needsBase64 = b
+		}
+
 		obj.Signatures[i].header = sig.Header
 		obj.Signatures[i].original = &original
+	}
+
+	// Only non-detached signatures with b64=false (default) are base64-encoded
+	if !detached && needsBase64 {
+		// Standard JWS signature
+		decoded, err := base64.RawURLEncoding.DecodeString(parsed.Payload)
+		if err != nil {
+			return nil, err
+		}
+		obj.payload = decoded
+	} else {
+		// RFC 7797 JWS Unencoded Payload Option or
+		// detached signature
+		obj.payload = []byte(parsed.Payload)
 	}
 
 	return obj, nil
@@ -390,11 +412,14 @@ func parseSignedCompact(
 		return nil, err
 	}
 
+	var pl string
+	var detached bool
 	if payload == nil {
-		payload, err = base64.RawURLEncoding.DecodeString(claims)
-		if err != nil {
-			return nil, err
-		}
+		detached = false
+		pl = claims
+	} else {
+		detached = true
+		pl = string(payload)
 	}
 
 	signature, err := base64.RawURLEncoding.DecodeString(sig)
@@ -403,11 +428,11 @@ func parseSignedCompact(
 	}
 
 	raw := &rawJSONWebSignature{
-		Payload:   newBuffer(payload),
+		Payload:   pl,
 		Protected: newBuffer(rawProtected),
 		Signature: newBuffer(signature),
 	}
-	return raw.sanitized(signatureAlgorithms)
+	return raw.sanitized(signatureAlgorithms, detached)
 }
 
 func (obj JSONWebSignature) compactSerialize(detached bool) (string, error) {
@@ -417,16 +442,34 @@ func (obj JSONWebSignature) compactSerialize(detached bool) (string, error) {
 
 	serializedProtected := mustSerializeJSON(obj.Signatures[0].protected)
 
+	needsBase64 := true
+	if b, err := obj.Signatures[0].protected.getB64(); err == nil {
+		needsBase64 = b
+	}
+
+	if !needsBase64 && !detached {
+		// RFC 7797 §7.2: Compact serialization with non-detached payload can only be used if the
+		// payload contains no '.' characters and is otherwise safe for transport.
+		if bytes.Contains(obj.payload, []byte{'.'}) {
+			return "", fmt.Errorf("payload contains '.' and cannot be represented in compact serialization (RFC 7797 §7.2)")
+		}
+	}
+
 	var payload []byte
 	if !detached {
 		payload = obj.payload
 	}
 
-	return base64JoinWithDots(
-		serializedProtected,
-		payload,
-		obj.Signatures[0].Signature,
-	), nil
+	protectedPart := base64.RawURLEncoding.EncodeToString(serializedProtected)
+	var payloadPart string
+	if needsBase64 {
+		payloadPart = base64.RawURLEncoding.EncodeToString(payload)
+	} else {
+		payloadPart = string(payload)
+	}
+	signaturePart := base64.RawURLEncoding.EncodeToString(obj.Signatures[0].Signature)
+
+	return strings.Join([]string{protectedPart, payloadPart, signaturePart}, "."), nil
 }
 
 // CompactSerialize serializes an object using the compact serialization format.
@@ -441,14 +484,17 @@ func (obj JSONWebSignature) DetachedCompactSerialize() (string, error) {
 
 // FullSerialize serializes an object using the full JSON serialization format.
 func (obj JSONWebSignature) FullSerialize() string {
-	raw := rawJSONWebSignature{
-		Payload: newBuffer(obj.payload),
-	}
 
+	raw := rawJSONWebSignature{}
+
+	needsBase64 := true
 	if len(obj.Signatures) == 1 {
 		if obj.Signatures[0].protected != nil {
 			serializedProtected := mustSerializeJSON(obj.Signatures[0].protected)
 			raw.Protected = newBuffer(serializedProtected)
+			if b, err := obj.Signatures[0].protected.getB64(); err == nil {
+				needsBase64 = b
+			}
 		}
 		raw.Header = obj.Signatures[0].header
 		raw.Signature = newBuffer(obj.Signatures[0].Signature)
@@ -462,8 +508,18 @@ func (obj JSONWebSignature) FullSerialize() string {
 
 			if signature.protected != nil {
 				raw.Signatures[i].Protected = newBuffer(mustSerializeJSON(signature.protected))
+				if b, err := obj.Signatures[0].protected.getB64(); err == nil {
+					needsBase64 = b
+				}
+
 			}
 		}
+	}
+
+	if needsBase64 {
+		raw.Payload = base64.RawURLEncoding.EncodeToString(obj.payload)
+	} else {
+		raw.Payload = string(obj.payload)
 	}
 
 	return string(mustSerializeJSON(raw))

--- a/jws.go
+++ b/jws.go
@@ -132,6 +132,11 @@ func ParseDetached(
 	if payload == nil {
 		return nil, errors.New("go-jose/go-jose: nil payload")
 	}
+	signature = stripWhitespace(signature)
+	if strings.HasPrefix(signature, "{") {
+		return parseSignedJSON(signature, payload, signatureAlgorithms)
+	}
+
 	return parseSignedCompact(stripWhitespace(signature), payload, signatureAlgorithms)
 }
 
@@ -186,13 +191,7 @@ func ParseSignedJSON(
 	input string,
 	signatureAlgorithms []SignatureAlgorithm,
 ) (*JSONWebSignature, error) {
-	var parsed rawJSONWebSignature
-	err := json.Unmarshal([]byte(input), &parsed)
-	if err != nil {
-		return nil, err
-	}
-
-	return parsed.sanitized(signatureAlgorithms, false)
+	return parseSignedJSON(input, nil, signatureAlgorithms)
 }
 
 func containsSignatureAlgorithm(haystack []SignatureAlgorithm, needle SignatureAlgorithm) bool {
@@ -435,6 +434,32 @@ func parseSignedCompact(
 	return raw.sanitized(signatureAlgorithms, detached)
 }
 
+// parseSignedJSON parses a message in JSON format.
+func parseSignedJSON(
+	input string,
+	payload []byte,
+	signatureAlgorithms []SignatureAlgorithm,
+) (*JSONWebSignature, error) {
+
+	var parsed rawJSONWebSignature
+	err := json.Unmarshal([]byte(input), &parsed)
+	if err != nil {
+		return nil, err
+	}
+
+	if parsed.Payload != "" && payload != nil {
+		return nil, fmt.Errorf("go-jose/go-jose: payload is not detached")
+	}
+
+	detached := false
+	if payload != nil {
+		detached = true
+		parsed.Payload = string(payload)
+	}
+
+	return parsed.sanitized(signatureAlgorithms, detached)
+}
+
 func (obj JSONWebSignature) compactSerialize(detached bool) (string, error) {
 	if len(obj.Signatures) != 1 || obj.Signatures[0].header != nil || obj.Signatures[0].protected == nil {
 		return "", ErrNotSupported
@@ -482,9 +507,7 @@ func (obj JSONWebSignature) DetachedCompactSerialize() (string, error) {
 	return obj.compactSerialize(true)
 }
 
-// FullSerialize serializes an object using the full JSON serialization format.
-func (obj JSONWebSignature) FullSerialize() string {
-
+func (obj JSONWebSignature) fullSerialize(detached bool) string {
 	raw := rawJSONWebSignature{}
 
 	needsBase64 := true
@@ -516,11 +539,23 @@ func (obj JSONWebSignature) FullSerialize() string {
 		}
 	}
 
-	if needsBase64 {
-		raw.Payload = base64.RawURLEncoding.EncodeToString(obj.payload)
-	} else {
-		raw.Payload = string(obj.payload)
+	if !detached {
+		if needsBase64 {
+			raw.Payload = base64.RawURLEncoding.EncodeToString(obj.payload)
+		} else {
+			raw.Payload = string(obj.payload)
+		}
 	}
 
 	return string(mustSerializeJSON(raw))
+}
+
+// FullSerialize serializes an object using the full JSON serialization format.
+func (obj JSONWebSignature) FullSerialize() string {
+	return obj.fullSerialize(false)
+}
+
+// DetachedFullSerialize serializes an object using the full JSON serialization format with detached payload.
+func (obj JSONWebSignature) DetachedFullSerialize() string {
+	return obj.fullSerialize(true)
 }

--- a/jws_test.go
+++ b/jws_test.go
@@ -429,7 +429,7 @@ func TestHeaderFieldsFull(t *testing.T) {
 }
 
 func TestErrorMissingPayloadJWS(t *testing.T) {
-	_, err := (&rawJSONWebSignature{}).sanitized([]SignatureAlgorithm{RS256})
+	_, err := (&rawJSONWebSignature{}).sanitized([]SignatureAlgorithm{RS256}, false)
 	if err == nil {
 		t.Error("was able to parse message with missing payload")
 	}

--- a/jws_test.go
+++ b/jws_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/go-jose/go-jose/v4/testutils/assert"
@@ -425,16 +424,6 @@ func TestHeaderFieldsFull(t *testing.T) {
 	}
 	if obj.Signatures[0].Unprotected.ExtraHeaders["custom"] != "test" {
 		t.Error("unprotected header did not contain custom header value")
-	}
-}
-
-func TestErrorMissingPayloadJWS(t *testing.T) {
-	_, err := (&rawJSONWebSignature{}).sanitized([]SignatureAlgorithm{RS256}, false)
-	if err == nil {
-		t.Error("was able to parse message with missing payload")
-	}
-	if !strings.Contains(err.Error(), "missing payload") {
-		t.Errorf("unexpected error message, should contain 'missing payload': %s", err)
 	}
 }
 

--- a/signing_test.go
+++ b/signing_test.go
@@ -572,9 +572,9 @@ func TestSignerExtraHeaderInclusion(t *testing.T) {
 	}
 }
 
-func TestSignerB64(t *testing.T) {
-	const exp = "eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.JC4wMg.A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"
+func TestSignVerifyParams(t *testing.T) {
 
+	// RFC 7517 Appendix A.1 example key
 	key := []byte{
 		0x03, 0x23, 0x35, 0x4b, 0x2b, 0x0f, 0xa5, 0xbc, 0x83, 0x7e, 0x06, 0x65, 0x77, 0x7b, 0xa6, 0x8f,
 		0x5a, 0xb3, 0x28, 0xe6, 0xf0, 0x54, 0xc9, 0x28, 0xa9, 0x0f, 0x84, 0xb2, 0xd2, 0x50, 0x2e, 0xbf,
@@ -582,42 +582,215 @@ func TestSignerB64(t *testing.T) {
 		0x3d, 0x2e, 0x21, 0x72, 0x05, 0x2e, 0x4f, 0x08, 0xc0, 0xcd, 0x9a, 0xf5, 0x67, 0xd0, 0x80, 0xa3,
 	}
 
-	opts := new(SignerOptions)
-	opts.WithBase64(false)
+	// RFC 7797 JWS Unencoded Payload Option Section 4 example data
+	data := []byte("$.02")
 
-	signer, err := NewSigner(SigningKey{Algorithm: HS256, Key: key}, opts)
+	// Alternative data for compact serialization with unencoded payload
+	data2 := []byte(`{"foo":"bar","baz":1}`)
+
+	type args struct {
+		key      []byte
+		data     []byte
+		payload  []byte
+		b64      bool
+		compact  bool
+		detached bool
+	}
+
+	// Tests with RFC 7797 JWS Unencoded Payload Option Section 4 example test vectors
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{
+			"Compact Detached",
+			args{key, data, data, true, true, true},
+			[]byte("eyJhbGciOiJIUzI1NiJ9..5mvfOroL-g7HyqJoozehmsaqmvTYGEq5jTI1gVvoEoQ"),
+			false,
+		},
+		{
+			"Compact",
+			args{key, data, nil, true, true, false},
+			[]byte("eyJhbGciOiJIUzI1NiJ9.JC4wMg.5mvfOroL-g7HyqJoozehmsaqmvTYGEq5jTI1gVvoEoQ"),
+			false,
+		},
+		{
+			"JSON Detached",
+			args{key, data, data, true, false, true},
+			[]byte(`{"protected":"eyJhbGciOiJIUzI1NiJ9","signature":"5mvfOroL-g7HyqJoozehmsaqmvTYGEq5jTI1gVvoEoQ"}`),
+			false,
+		},
+		{
+			"JSON",
+			args{key, data, nil, true, false, false},
+			[]byte(`{"protected":"eyJhbGciOiJIUzI1NiJ9","payload":"JC4wMg","signature":"5mvfOroL-g7HyqJoozehmsaqmvTYGEq5jTI1gVvoEoQ"}`),
+			false,
+		},
+		{
+			"Compact Detached Unencoded Payload",
+			args{key, data, data, false, true, true},
+			[]byte("eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"),
+			false,
+		},
+		{
+			"Compact Unencoded Payload",
+			args{key, data2, nil, false, true, false},
+			[]byte(`eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.{"foo":"bar","baz":1}.QF66nY6IARUiw-7w2R7xAQulIUhm1wQLrG7GVn8qPR8`),
+			false,
+		},
+		{
+			"JSON Detached Unencoded Payload",
+			args{key, data, data, false, false, true},
+			[]byte(`{"protected":"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19","signature":"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"}`),
+			false,
+		},
+		{
+			"JSON Unencoded Payload",
+			args{key, data, nil, false, false, false},
+			[]byte(`{"protected":"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19","payload":"$.02","signature":"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"}`),
+			false,
+		},
+		{
+			"JSON Unencoded Payload Alternative Data Needs Unescaping",
+			args{key, data2, nil, false, false, false},
+			[]byte(`{"protected":"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19","payload":"{\"foo\":\"bar\",\"baz\":1}","signature":"QF66nY6IARUiw-7w2R7xAQulIUhm1wQLrG7GVn8qPR8"}`),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			signed, err := signWithParams(tt.args.data, tt.args.key, tt.args.b64, tt.args.compact, tt.args.detached)
+			if err != nil {
+				t.Errorf("failed to sign: %v", err)
+			}
+
+			err = verifyWithParams(signed, tt.args.key, tt.args.payload)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TestSignVerifyParams() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			equal := testEqual(signed, tt.want, tt.args.compact)
+			if !equal {
+				t.Errorf("Expected '%v', got '%v'", string(tt.want), string(signed))
+			}
+		})
+	}
+}
+
+func signWithParams(data []byte, secret []byte, b64, compact, detached bool) ([]byte, error) {
+
+	if len(secret) == 0 {
+		return nil, fmt.Errorf("secret key must not be empty")
+	}
+
+	opts := (&SignerOptions{}).WithBase64(b64)
+
+	signer, err := NewSigner(SigningKey{Algorithm: HS256, Key: secret}, opts)
 	if err != nil {
-		t.Error("Failed to create signer")
+		return nil, fmt.Errorf("failed to create HMAC signer: %w", err)
 	}
 
-	input := []byte("$.02")
-
-	obj, err := signer.Sign(input)
+	obj, err := signer.Sign(data)
 	if err != nil {
-		t.Error("Failed to sign payload")
+		return nil, fmt.Errorf("failed to sign new JWS: %w", err)
 	}
 
-	msg, err := obj.CompactSerialize()
+	if compact {
+		if detached {
+			out, err := obj.DetachedCompactSerialize()
+			if err != nil {
+				return nil, fmt.Errorf("failed to serialize with compact serialization: %w", err)
+			}
+			return []byte(out), nil
+		} else {
+			out, err := obj.CompactSerialize()
+			if err != nil {
+				return nil, fmt.Errorf("failed to serialize with compact serialization: %w", err)
+			}
+			return []byte(out), nil
+		}
+	} else {
+		if detached {
+			return []byte(obj.DetachedFullSerialize()), nil
+		} else {
+			return []byte(obj.FullSerialize()), nil
+		}
+	}
+}
+
+func verifyWithParams(data []byte, secret []byte, payload []byte) error {
+	if payload == nil {
+		return verify(data, secret)
+	} else {
+		err := verifyDetached1(data, secret, payload)
+		if err != nil {
+			return err
+		}
+		return verifyDetached2(data, secret, payload)
+	}
+}
+
+func verify(data []byte, secret []byte) error {
+
+	object, err := ParseSigned(string(data), []SignatureAlgorithm{HS256})
 	if err != nil {
-		t.Error("Failed to serialize")
+		return fmt.Errorf("failed to parse JWS: %w", err)
 	}
 
-	if msg != exp {
-		t.Errorf("Invalid serialization, got '%s', expected '%s'", msg, exp)
-	}
-
-	parsed, err := ParseSigned(msg, []SignatureAlgorithm{HS256})
+	_, err = object.Verify(secret)
 	if err != nil {
-		t.Errorf("Error on parse: %s", err)
+		return fmt.Errorf("failed to verify HMAC signature: %w", err)
 	}
 
-	output, err := parsed.Verify(key)
+	return nil
+}
+
+func verifyDetached1(data []byte, secret []byte, payload []byte) error {
+
+	object, err := ParseDetached(string(data), payload, []SignatureAlgorithm{HS256})
 	if err != nil {
-		t.Errorf("Error on verify: %s", err)
+		return fmt.Errorf("failed to parse JWS with detached payload: %w", err)
 	}
 
-	if !bytes.Equal(output, input) {
-		t.Errorf("Input/output do not match, got '%s', expected '%s'", output, input)
+	_, err = object.Verify(secret)
+	if err != nil {
+		return fmt.Errorf("failed to verify HMAC signature: %w", err)
+	}
+
+	return nil
+
+}
+
+func verifyDetached2(data []byte, secret []byte, payload []byte) error {
+
+	object, err := ParseSigned(string(data), []SignatureAlgorithm{HS256})
+	if err != nil {
+		return fmt.Errorf("failed to parse JWS: %w", err)
+	}
+
+	err = object.DetachedVerify(payload, secret)
+	if err != nil {
+		return fmt.Errorf("failed to verify HMAC signature %w", err)
+	}
+
+	return nil
+}
+
+func testEqual(got, expected []byte, compact bool) bool {
+	if compact {
+		return reflect.DeepEqual(got, expected)
+	} else {
+		var obj1, obj2 interface{}
+		if err := json.Unmarshal(got, &obj1); err != nil {
+			panic(err)
+		}
+		if err := json.Unmarshal(expected, &obj2); err != nil {
+			panic(err)
+		}
+		return reflect.DeepEqual(obj1, obj2)
 	}
 }
 


### PR DESCRIPTION
The JOSE RFC7797 “b64” header parameter was already respected during signature computation, but serialization and deserialization always base64url-encoded/decoded the payload, even when "b64" was set to false. This resulted in invalid JWS objects according to RFC 7797.

For example, given the test data in RFC7797 Section 4.2, the library produced this JWS: 
```
{
      "protected": "eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",
      "payload": "JC4wMg",
      "signature": "A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"
}
```

However, according to EFC7797, the correct JWS should be: 
```
{
      "protected": "eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",
      "payload": "$.02",
      "signature": "A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"
}
```
Note that the signature computation was already correct, only the payload handling was wrong, since rawJSONWebSignature used the byteBuffer type, which performed base64url encoding/decoding automatically during JSON (un)marshalling.
    
This pull request  fixes that behaviour by implementing the RFC7797 unencoded payload option and adds new tests that cover all RFC7797 test vectors.

As unencoded payloads may appear in JWS objects, the decision of whether to base64-decode the payload must be deferred until after the "b64" header parameter has been parsed. To support this, the payload type was changed from byteBuffer (which auto-decodes during unmarshalling) to string, and the decode decision is now performed explicitly.

The final commit furthermore adds the DetachedFullSerialize() method, to support the JSON Full Serialization form with detached payloads. I can also split this into 2 PRs if desired, but first wanted to check if any of this has a chance of getting accepted. 