### PR TITLE
remove err == nil pattern

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -258,6 +258,10 @@ func (ctx *genericEncrypter) addRecipient(recipient Recipient) (err error) {
 	}
 
 	recipientInfo, err = makeJWERecipient(recipient.Algorithm, recipient.Key)
+	if err != nil {
+		return err
+	}
+
 	if recipient.KeyID != "" {
 		recipientInfo.keyID = recipient.KeyID
 	}
@@ -270,10 +274,8 @@ func (ctx *genericEncrypter) addRecipient(recipient Recipient) (err error) {
 		}
 	}
 
-	if err == nil {
-		ctx.recipients = append(ctx.recipients, recipientInfo)
-	}
-	return err
+	ctx.recipients = append(ctx.recipients, recipientInfo)
+	return nil
 }
 
 func makeJWERecipient(alg KeyAlgorithm, encryptionKey interface{}) (recipientKeyInfo, error) {
@@ -490,12 +492,13 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 	recipientHeaders := obj.mergedHeaders(&recipient)
 
 	cek, err := decrypter.decryptKey(recipientHeaders, &recipient, generator)
-	if err == nil {
-		// Found a valid CEK -- let's try to decrypt.
-		plaintext, err = cipher.decrypt(cek, authData, parts)
+	if err != nil {
+		return nil, ErrCryptoFailure
 	}
 
-	if plaintext == nil {
+	// Found a valid CEK -- let's try to decrypt.
+	plaintext, err = cipher.decrypt(cek, authData, parts)
+	if err != nil {
 		return nil, ErrCryptoFailure
 	}
 
@@ -559,22 +562,32 @@ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Heade
 	var plaintext []byte
 	var headers rawHeader
 
+	if len(obj.recipients) == 0 {
+		return -1, Header{}, nil, errors.New("go-jose/go-jose: no recipients")
+	}
+
+	// Loop sets `err` in the function scope; don't shadow it.
 	for i, recipient := range obj.recipients {
 		recipientHeaders := obj.mergedHeaders(&recipient)
 
-		cek, err := decrypter.decryptKey(recipientHeaders, &recipient, generator)
-		if err == nil {
-			// Found a valid CEK -- let's try to decrypt.
-			plaintext, err = cipher.decrypt(cek, authData, parts)
-			if err == nil {
-				index = i
-				headers = recipientHeaders
-				break
-			}
+		var cek []byte
+		cek, err = decrypter.decryptKey(recipientHeaders, &recipient, generator)
+		if err != nil {
+			continue
 		}
+
+		// Found a valid CEK -- let's try to decrypt.
+		plaintext, err = cipher.decrypt(cek, authData, parts)
+		if err != nil {
+			continue
+		}
+
+		index = i
+		headers = recipientHeaders
+		break
 	}
 
-	if plaintext == nil {
+	if err != nil {
 		return -1, Header{}, nil, ErrCryptoFailure
 	}
 

--- a/crypter_test.go
+++ b/crypter_test.go
@@ -748,6 +748,39 @@ func TestRejectTooHighP2C(t *testing.T) {
 	}
 }
 
+func TestDecryptEmptyPlaintext(t *testing.T) {
+	encAlg := A128GCM
+	keyAlg := DIRECT
+	testKeys := generateTestKeys(DIRECT, encAlg)
+	rcpt := Recipient{Algorithm: keyAlg, Key: testKeys[0].enc}
+	enc, err := NewEncrypter(encAlg, rcpt, nil)
+	if err != nil {
+		t.Fatalf("error on new encrypter: %s", err)
+	}
+
+	var plaintext []byte
+	obj, err := enc.EncryptWithAuthData(plaintext, nil)
+	if err != nil {
+		t.Fatalf("error in encrypt: %s", err)
+	}
+
+	msg := obj.FullSerialize()
+
+	parsed, err := ParseEncryptedJSON(msg, []KeyAlgorithm{keyAlg}, []ContentEncryption{encAlg})
+	if err != nil {
+		t.Fatalf("error in parse: %s, on msg '%s'", err, msg)
+	}
+
+	output, err := parsed.Decrypt(testKeys[0].dec)
+	if err != nil {
+		t.Fatalf("error on decrypt: %s", err)
+	}
+
+	if !bytes.Equal(plaintext, output) {
+		t.Fatalf("Decrypted(): got %q, want %q", output, plaintext)
+	}
+}
+
 type testKey struct {
 	enc, dec interface{}
 }

--- a/jwe_test.go
+++ b/jwe_test.go
@@ -380,13 +380,13 @@ func TestVectorsJWECorrupt(t *testing.T) {
 	msg, _ := ParseEncrypted(corruptCiphertext, []KeyAlgorithm{RSA_OAEP}, []ContentEncryption{A128GCM})
 	_, err := msg.Decrypt(priv)
 	if err != ErrCryptoFailure {
-		t.Error("should detect corrupt ciphertext")
+		t.Errorf("Decrypt(): got %q, want %q", err, ErrCryptoFailure)
 	}
 
 	msg, _ = ParseEncrypted(corruptAuthtag, []KeyAlgorithm{RSA_OAEP}, []ContentEncryption{A128GCM})
 	_, err = msg.Decrypt(priv)
 	if err != ErrCryptoFailure {
-		t.Error("should detect corrupt auth tag")
+		t.Errorf("Decrypt(): got %q, want %q", err, ErrCryptoFailure)
 	}
 }
 

--- a/jwk.go
+++ b/jwk.go
@@ -207,21 +207,29 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 	case "EC":
 		if raw.D != nil {
 			key, err = raw.ecPrivateKey()
-			if err == nil {
-				keyPub = key.(*ecdsa.PrivateKey).Public()
+			if err != nil {
+				return err
 			}
+			keyPub = key.(*ecdsa.PrivateKey).Public()
 		} else {
 			key, err = raw.ecPublicKey()
+			if err != nil {
+				return err
+			}
 			keyPub = key
 		}
 	case "RSA":
 		if raw.D != nil {
 			key, err = raw.rsaPrivateKey()
-			if err == nil {
-				keyPub = key.(*rsa.PrivateKey).Public()
+			if err != nil {
+				return err
 			}
+			keyPub = key.(*rsa.PrivateKey).Public()
 		} else {
 			key, err = raw.rsaPublicKey()
+			if err != nil {
+				return err
+			}
 			keyPub = key
 		}
 	case "oct":
@@ -229,25 +237,28 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 			return errors.New("go-jose/go-jose: invalid JWK, found 'oct' (symmetric) key with cert chain")
 		}
 		key, err = raw.symmetricKey()
+		if err != nil {
+			return err
+		}
 	case "OKP":
 		if raw.Crv == "Ed25519" {
 			if raw.D != nil {
 				key, err = raw.edPrivateKey()
-				if err == nil {
-					keyPub = key.(ed25519.PrivateKey).Public()
+				if err != nil {
+					return err
 				}
+				keyPub = key.(ed25519.PrivateKey).Public()
 			} else {
 				key, err = raw.edPublicKey()
+				if err != nil {
+					return err
+				}
 				keyPub = key
 			}
 		}
 	case "":
 		// kty MUST be present
-		err = fmt.Errorf("go-jose/go-jose: missing json web key type")
-	}
-
-	if err != nil {
-		return
+		return fmt.Errorf("go-jose/go-jose: missing json web key type")
 	}
 
 	if key == nil {

--- a/signing.go
+++ b/signing.go
@@ -432,11 +432,11 @@ func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey inter
 	headers := signature.mergedHeaders()
 	alg := headers.getSignatureAlgorithm()
 	err = verifier.verifyPayload(input, signature.Signature, alg)
-	if err == nil {
-		return nil
+	if err != nil {
+		return ErrCryptoFailure
 	}
 
-	return ErrCryptoFailure
+	return nil
 }
 
 // VerifyMulti validates (one of the multiple) signatures on the object and
@@ -476,7 +476,6 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 		return -1, Signature{}, err
 	}
 
-outer:
 	for i, signature := range obj.Signatures {
 		if signature.header != nil {
 			// Per https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.11,
@@ -486,7 +485,7 @@ outer:
 			// Protected Header."
 			err = signature.header.checkNoCritical()
 			if err != nil {
-				continue outer
+				continue
 			}
 		}
 
@@ -494,7 +493,7 @@ outer:
 			// Check for only supported critical headers
 			err = signature.protected.checkSupportedCritical(supportedCritical)
 			if err != nil {
-				continue outer
+				continue
 			}
 		}
 
@@ -506,9 +505,11 @@ outer:
 		headers := signature.mergedHeaders()
 		alg := headers.getSignatureAlgorithm()
 		err = verifier.verifyPayload(input, signature.Signature, alg)
-		if err == nil {
-			return i, signature, nil
+		if err != nil {
+			continue
 		}
+
+		return i, signature, nil
 	}
 
 	return -1, Signature{}, ErrCryptoFailure


### PR DESCRIPTION
In a few places, particularly when checking for successful decryption or
authentication by a list of keys, the code was checking for `err == nil` to
indicate success, instead of checking for `err != nil` to indicate failure.

This makes it hard to return the underlying error when appropriate (though this
PR does not yet change passthrough of errors). Also, in one related case where
the code was checking for `plaintext == nil` to indicate error, we incorrectly
rejected decryption when it resulted in a legitimately empty plaintext.

Fixes #43
Supersedes #44