### PR TITLE
fix: preserve parsed protected header bytes when serializing JWS

### DIFF
--- a/jws.go
+++ b/jws.go
@@ -143,6 +143,20 @@ func (sig Signature) mergedHeaders() rawHeader {
 	return out
 }
 
+// serializedProtected returns the protected header bytes to use when
+// serializing a signature. If the signature was parsed from an existing
+// token, the original protected header bytes are reused so that the
+// signature stays valid for the re-serialized output.
+func (sig Signature) serializedProtected() []byte {
+	if sig.original != nil && sig.original.Protected != nil {
+		return sig.original.Protected.bytes()
+	}
+	if sig.protected != nil {
+		return mustSerializeJSON(sig.protected)
+	}
+	return nil
+}
+
 // Compute data to be signed
 func (obj JSONWebSignature) computeAuthData(payload []byte, signature *Signature) ([]byte, error) {
 	var authData bytes.Buffer
@@ -423,7 +437,7 @@ func (obj JSONWebSignature) compactSerialize(detached bool) (string, error) {
 		return "", ErrNotSupported
 	}
 
-	serializedProtected := mustSerializeJSON(obj.Signatures[0].protected)
+	serializedProtected := obj.Signatures[0].serializedProtected()
 
 	var payload []byte
 	if !detached {
@@ -454,8 +468,7 @@ func (obj JSONWebSignature) FullSerialize() string {
 	}
 
 	if len(obj.Signatures) == 1 {
-		if obj.Signatures[0].protected != nil {
-			serializedProtected := mustSerializeJSON(obj.Signatures[0].protected)
+		if serializedProtected := obj.Signatures[0].serializedProtected(); serializedProtected != nil {
 			raw.Protected = newBuffer(serializedProtected)
 		}
 		raw.Header = obj.Signatures[0].header
@@ -468,8 +481,8 @@ func (obj JSONWebSignature) FullSerialize() string {
 				Signature: newBuffer(signature.Signature),
 			}
 
-			if signature.protected != nil {
-				raw.Signatures[i].Protected = newBuffer(mustSerializeJSON(signature.protected))
+			if serializedProtected := signature.serializedProtected(); serializedProtected != nil {
+				raw.Signatures[i].Protected = newBuffer(serializedProtected)
 			}
 		}
 	}

--- a/jws_test.go
+++ b/jws_test.go
@@ -710,6 +710,44 @@ func TestDetachedCompactSerialization(t *testing.T) {
 	}
 }
 
+func TestSerializePreservesParsedProtectedHeader(t *testing.T) {
+	// Protected header here is {"typ":"JWT","alg":"HS256"}, which is not in
+	// alphabetical key order. Re-marshaling the parsed header map would sort
+	// the keys, changing the signed bytes and invalidating the signature.
+	msg := "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.HwIsK3apeAFigSjP3j79CA3Pt1rAdb220riTBjMaoWw"
+	key := []byte("0123456789ABCDEF0123456789ABCDEF")
+
+	obj, err := ParseSigned(msg, []SignatureAlgorithm{HS256})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compact, err := obj.CompactSerialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compact != msg {
+		t.Fatalf("CompactSerialize changed token\n got: %s\nwant: %s", compact, msg)
+	}
+
+	full := obj.FullSerialize()
+	parsed, err := ParseSigned(full, []SignatureAlgorithm{HS256})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parsed.Verify(key); err != nil {
+		t.Fatalf("signature invalid after FullSerialize round trip: %v", err)
+	}
+
+	reparsed, err := ParseSigned(compact, []SignatureAlgorithm{HS256})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reparsed.Verify(key); err != nil {
+		t.Fatalf("signature invalid after CompactSerialize round trip: %v", err)
+	}
+}
+
 func TestJWSComputeAuthDataBase64(t *testing.T) {
 	jws := JSONWebSignature{}
 


### PR DESCRIPTION
When a JWS is parsed and then re-serialized via CompactSerialize, DetachedCompactSerialize, or FullSerialize, the protected header was re-marshaled from a Go map, which sorts keys alphabetically and changes the exact signed bytes, invalidating the signature. This reuses the original protected header bytes preserved during parsing so a parse then serialize round trip keeps the signature valid. Closes #228.