### PR TITLE
json: report actual JSON kind in UnmarshalText type errors

### DIFF
--- a/json/decode.go
+++ b/json/decode.go
@@ -797,7 +797,20 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 			if fromQuoted {
 				d.saveError(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
 			} else {
-				d.saveError(&UnmarshalTypeError{"string", v.Type(), int64(d.off)})
+				var val string
+				switch item[0] {
+				case 'n':
+					val = "null"
+				case 't', 'f':
+					val = "bool"
+				case '[':
+					val = "array"
+				case '{':
+					val = "object"
+				default:
+					val = "number"
+				}
+				d.saveError(&UnmarshalTypeError{val, v.Type(), int64(d.off)})
 			}
 			return
 		}

--- a/json/decode_test.go
+++ b/json/decode_test.go
@@ -1433,7 +1433,7 @@ var invalidUnmarshalTextTests = []struct {
 	{nil, "json: Unmarshal(nil)"},
 	{struct{}{}, "json: Unmarshal(non-pointer struct {})"},
 	{(*int)(nil), "json: Unmarshal(nil *int)"},
-	{new(net.IP), "json: cannot unmarshal string into Go value of type *net.IP"},
+	{new(net.IP), "json: cannot unmarshal number into Go value of type *net.IP"},
 }
 
 func TestInvalidUnmarshalText(t *testing.T) {
@@ -1446,6 +1446,36 @@ func TestInvalidUnmarshalText(t *testing.T) {
 		}
 		if got := err.Error(); got != tt.want {
 			t.Errorf("Unmarshal = %q; want %q", got, tt.want)
+		}
+	}
+}
+
+// TestUnmarshalTextTypeMismatch verifies that when a non-string JSON value is
+// decoded into a TextUnmarshaler, the resulting UnmarshalTypeError reports the
+// actual JSON kind rather than always saying "string". Regression for #217.
+func TestUnmarshalTextTypeMismatch(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{`123`, "number"},
+		{`-1.5`, "number"},
+		{`true`, "bool"},
+		{`false`, "bool"},
+		{`null`, "null"},
+		{`[1,2]`, "array"},
+		{`{"a":1}`, "object"},
+	}
+	for _, tc := range cases {
+		var ip net.IP
+		err := Unmarshal([]byte(tc.in), &ip)
+		ute, ok := err.(*UnmarshalTypeError)
+		if !ok {
+			t.Errorf("Unmarshal(%s) = %v (%T); want *UnmarshalTypeError", tc.in, err, err)
+			continue
+		}
+		if ute.Value != tc.want {
+			t.Errorf("Unmarshal(%s) Value = %q; want %q", tc.in, ute.Value, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #217.

The bundled `json` package always reported `"string"` as the offending kind when a non-string JSON value hit a `TextUnmarshaler`, e.g. decoding `123` into a `net.IP` got you `json: cannot unmarshal string into Go value of type *net.IP`. That's the opposite of what's actually happening; the JSON value isn't a string, that's why we're erroring.

This mirrors the dispatch upstream `encoding/json` uses and reports `number`, `bool`, `null`, `array`, or `object` as appropriate.

The existing `TestInvalidUnmarshalText` had the bug baked into its expected string, so I updated it. Also added a focused regression test covering each non-string JSON kind.