### PR TITLE
preserve the original protected header bytes when re-serializing a JWS

### DIFF
--- a/jws.go
+++ b/jws.go
@@ -423,7 +423,10 @@ func (obj JSONWebSignature) compactSerialize(detached bool) (string, error) {
 		return "", ErrNotSupported
 	}
 
-	serializedProtected := mustSerializeJSON(obj.Signatures[0].protected)
+	// Round-tripping a parsed JWS must preserve the original protected
+	// header bytes, otherwise re-marshaling the protected map would
+	// reorder its keys and invalidate the existing signature. See #228.
+	serializedProtected := protectedHeaderBytes(&obj.Signatures[0])
 
 	var payload []byte
 	if !detached {
@@ -435,6 +438,17 @@ func (obj JSONWebSignature) compactSerialize(detached bool) (string, error) {
 		payload,
 		obj.Signatures[0].Signature,
 	), nil
+}
+
+// protectedHeaderBytes returns the byte sequence that should be used
+// when serializing sig's protected header. If sig was parsed from a
+// signed input, the original bytes are returned so the resulting
+// serialization stays signature-compatible with the input.
+func protectedHeaderBytes(sig *Signature) []byte {
+	if sig.original != nil && sig.original.Protected != nil {
+		return sig.original.Protected.bytes()
+	}
+	return mustSerializeJSON(sig.protected)
 }
 
 // CompactSerialize serializes an object using the compact serialization format.
@@ -455,8 +469,7 @@ func (obj JSONWebSignature) FullSerialize() string {
 
 	if len(obj.Signatures) == 1 {
 		if obj.Signatures[0].protected != nil {
-			serializedProtected := mustSerializeJSON(obj.Signatures[0].protected)
-			raw.Protected = newBuffer(serializedProtected)
+			raw.Protected = newBuffer(protectedHeaderBytes(&obj.Signatures[0]))
 		}
 		raw.Header = obj.Signatures[0].header
 		raw.Signature = newBuffer(obj.Signatures[0].Signature)
@@ -469,7 +482,7 @@ func (obj JSONWebSignature) FullSerialize() string {
 			}
 
 			if signature.protected != nil {
-				raw.Signatures[i].Protected = newBuffer(mustSerializeJSON(signature.protected))
+				raw.Signatures[i].Protected = newBuffer(protectedHeaderBytes(&obj.Signatures[i]))
 			}
 		}
 	}

--- a/jws_test.go
+++ b/jws_test.go
@@ -17,6 +17,8 @@
 package jose
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
@@ -773,6 +775,46 @@ func TestInvalidHMACKeySize(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = s.Sign([]byte("Lorem ipsum dolor sit amet"))
 	assert.ErrorIs(t, err, ErrInvalidKeySize)
+}
+
+// Regression for #228. CompactSerialize used to re-marshal the
+// protected header map, which sorts keys alphabetically and produced
+// a serialization whose protected-header bytes no longer matched the
+// signed bytes. Round-tripping a parsed JWS must preserve the
+// original protected-header bytes so the signature stays valid.
+func TestRoundTripPreservesProtectedHeaderBytes(t *testing.T) {
+	algs := []SignatureAlgorithm{HS256}
+	key := []byte("super-secret-key-thats-long-enough")
+
+	// Craft a JWS whose protected header is NOT in alphabetical order
+	// so the re-marshal path would visibly reorder it. Sign and serialize
+	// once so we have a token to round-trip.
+	const headerJSON = `{"typ":"JWT","alg":"HS256"}`
+	const payload = `{"sub":"123"}`
+	const protectedB64 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+	if got := base64.RawURLEncoding.EncodeToString([]byte(headerJSON)); got != protectedB64 {
+		t.Fatalf("test setup mismatch, expected %q, got %q", protectedB64, got)
+	}
+	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(protectedB64 + "." + payloadB64))
+	sigB64 := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	raw := protectedB64 + "." + payloadB64 + "." + sigB64
+
+	parsed, err := ParseSigned(raw, algs)
+	assert.NoError(t, err)
+
+	got, err := parsed.CompactSerialize()
+	assert.NoError(t, err)
+	if got != raw {
+		t.Fatalf("CompactSerialize round-trip changed bytes:\nwant %s\n got %s", raw, got)
+	}
+
+	reparsed, err := ParseSigned(got, algs)
+	assert.NoError(t, err)
+	if _, err := reparsed.Verify(key); err != nil {
+		t.Fatalf("re-parsed JWS no longer verifies: %v", err)
+	}
 }
 
 func BenchmarkParseSignedCompat(b *testing.B) {


### PR DESCRIPTION
Fixes #228.

\`CompactSerialize\`, \`DetachedCompactSerialize\`, and \`FullSerialize\` all re-marshal \`signature.protected\` through \`mustSerializeJSON\`. Because the protected header is a Go map, that reorders the keys alphabetically. JWS signatures cover the exact base64url-encoded protected header bytes, so a round-trip through \`ParseSigned -> CompactSerialize\` produced a different protected segment and invalidated the signature for anyone re-parsing the output.

\`ParseSigned\` already preserves the original bytes in \`signature.original.Protected\`, and verification reads them via \`computeAuthData\`. Use the same source on the serialize path so the output stays signature-compatible with the parsed input. Newly built signatures (no original bytes) fall back to the existing \`mustSerializeJSON\` path.

Added \`TestRoundTripPreservesProtectedHeaderBytes\` which crafts a JWS with non-alphabetical header key order, round-trips through CompactSerialize, and asserts the output is byte-identical to the input and still verifies against the original key.