### PR TITLE
remove bare returns outside the json/ fork

### DIFF
--- a/jose-util/generator/encoding.go
+++ b/jose-util/generator/encoding.go
@@ -49,5 +49,5 @@ func (r Base64Reader) Read(p []byte) (n int, err error) {
 		err = io.EOF
 	}
 
-	return
+	return n, err
 }

--- a/jwk.go
+++ b/jwk.go
@@ -348,7 +348,7 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		}
 	}
 
-	return
+	return nil
 }
 
 // JSONWebKeySet represents a JWK Set object.

--- a/shared.go
+++ b/shared.go
@@ -477,7 +477,7 @@ func (parsed rawHeader) sanitized() (h Header, err error) {
 			h.ExtraHeaders[k] = v2
 		}
 	}
-	return
+	return h, nil
 }
 
 func parseCertificateChain(chain []string) ([]*x509.Certificate, error) {


### PR DESCRIPTION
For #142.

Three named-return functions had bare \`return\` statements where it's not immediately obvious from the closing line which value is going back. Made them explicit (\`return nil\`, \`return h, nil\`, \`return n, err\`) so the intent is at the call site instead of one helpful scroll up.

Left \`json/decode.go\` alone since that package is a fork of stdlib \`encoding/json\` and the readable diff against upstream is the point.