### PR TITLE
encoding/flate: improve deflate performance and allocations

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"math/big"
 	"strings"
+	"sync"
 	"unicode"
 
 	"github.com/go-jose/go-jose/v4/json"
@@ -86,15 +87,29 @@ func decompress(algorithm CompressionAlgorithm, input []byte) ([]byte, error) {
 	}
 }
 
+var flateWriterPool sync.Pool
+
+func newFlateWriter(output io.Writer) *flate.Writer {
+	if v := flateWriterPool.Get(); v != nil {
+		e := v.(*flate.Writer)
+		e.Reset(output)
+		return e
+	}
+	// Writing to byte buffer, err is always nil
+	w, _ := flate.NewWriter(output, 1)
+	return w
+}
+
 // deflate compresses the input.
 func deflate(input []byte) ([]byte, error) {
 	output := new(bytes.Buffer)
 
-	// Writing to byte buffer, err is always nil
-	writer, _ := flate.NewWriter(output, 1)
+	writer := newFlateWriter(output)
 	_, _ = io.Copy(writer, bytes.NewBuffer(input))
 
 	err := writer.Close()
+	flateWriterPool.Put(writer)
+
 	return output.Bytes(), err
 }
 

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -154,3 +154,13 @@ func TestFixedSizeBufferTooLarge(t *testing.T) {
 
 	newFixedSizeBuffer(make([]byte, 2), 1)
 }
+
+func BenchmarkDeflate(b *testing.B) {
+	input := []byte(`{"sub":"1234567890","name":"John Doe","iat":1516239022}`)
+	for b.Loop() {
+		if _, err := deflate(input); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+}


### PR DESCRIPTION
* use a sync.Pool for flate.Writer
* benchmarks 
goos: darwin
goarch: arm64
pkg: github.com/go-jose/go-jose/v4
cpu: Apple M4 Pro
```
           │     old      │                 new                 │
           │    sec/op    │   sec/op     vs base                │
Deflate-12   11.623µ ± 1%   1.976µ ± 1%  -83.00% (p=0.000 n=10)

           │      old       │                new                 │
           │      B/op      │    B/op     vs base                │
Deflate-12   1204896.0 ± 0%   289.0 ± 0%  -99.98% (p=0.000 n=10)

           │     old     │                new                 │
           │  allocs/op  │ allocs/op   vs base                │
Deflate-12   21.000 ± 0%   4.000 ± 0%  -80.95% (p=0.000 n=10)
```