### PR TITLE
Handle JWE JSON without protected header

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -502,7 +502,7 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 		return nil, ErrCryptoFailure
 	}
 
-	plaintext, err = obj.decompressProtected(plaintext)
+	plaintext, err = obj.decompress(plaintext)
 	if err != nil {
 		return nil, err
 	}
@@ -588,7 +588,7 @@ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Heade
 		return -1, Header{}, nil, ErrCryptoFailure
 	}
 
-	plaintext, err = obj.decompressProtected(plaintext)
+	plaintext, err = obj.decompress(plaintext)
 	if err != nil {
 		return -1, Header{}, nil, err
 	}
@@ -601,7 +601,9 @@ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Heade
 	return index, sanitized, plaintext, err
 }
 
-func (obj JSONWebEncryption) decompressProtected(plaintext []byte) ([]byte, error) {
+// decompress decompresses plaintext using the protected "zip" header, if present.
+// It returns plaintext unchanged when there is no protected header or "zip" value.
+func (obj JSONWebEncryption) decompress(plaintext []byte) ([]byte, error) {
 	if obj.protected == nil {
 		return plaintext, nil
 	}

--- a/crypter.go
+++ b/crypter.go
@@ -502,12 +502,9 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 		return nil, ErrCryptoFailure
 	}
 
-	// The "zip" header parameter may only be present in the protected header.
-	if comp := obj.protected.getCompression(); comp != "" {
-		plaintext, err = decompress(comp, plaintext)
-		if err != nil {
-			return nil, fmt.Errorf("go-jose/go-jose: failed to decompress plaintext: %v", err)
-		}
+	plaintext, err = obj.decompressProtected(plaintext)
+	if err != nil {
+		return nil, err
 	}
 
 	return plaintext, nil
@@ -591,12 +588,9 @@ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Heade
 		return -1, Header{}, nil, ErrCryptoFailure
 	}
 
-	// The "zip" header parameter may only be present in the protected header.
-	if comp := obj.protected.getCompression(); comp != "" {
-		plaintext, err = decompress(comp, plaintext)
-		if err != nil {
-			return -1, Header{}, nil, fmt.Errorf("go-jose/go-jose: failed to decompress plaintext: %v", err)
-		}
+	plaintext, err = obj.decompressProtected(plaintext)
+	if err != nil {
+		return -1, Header{}, nil, err
 	}
 
 	sanitized, err := headers.sanitized()
@@ -605,4 +599,21 @@ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Heade
 	}
 
 	return index, sanitized, plaintext, err
+}
+
+func (obj JSONWebEncryption) decompressProtected(plaintext []byte) ([]byte, error) {
+	if obj.protected == nil {
+		return plaintext, nil
+	}
+
+	comp := obj.protected.getCompression()
+	if comp == "" {
+		return plaintext, nil
+	}
+
+	plaintext, err := decompress(comp, plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("go-jose/go-jose: failed to decompress plaintext: %v", err)
+	}
+	return plaintext, nil
 }

--- a/jwe_test.go
+++ b/jwe_test.go
@@ -352,6 +352,68 @@ func TestJWENilProtected(t *testing.T) {
 	}
 }
 
+func TestJWEDecryptWithoutProtectedHeader(t *testing.T) {
+	key := []byte("0123456789abcdef")
+	plaintext := []byte("secret")
+	token := jweJSONWithoutProtectedHeader(t, key, plaintext)
+
+	parsed, err := ParseEncryptedJSON(
+		token,
+		[]KeyAlgorithm{DIRECT},
+		[]ContentEncryption{A128GCM},
+	)
+	if err != nil {
+		t.Fatalf("ParseEncryptedJSON: %v", err)
+	}
+
+	decrypted, err := parsed.Decrypt(key)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Fatalf("Decrypt plaintext = %q, want %q", decrypted, plaintext)
+	}
+
+	index, _, decrypted, err := parsed.DecryptMulti(key)
+	if err != nil {
+		t.Fatalf("DecryptMulti: %v", err)
+	}
+	if index != 0 {
+		t.Fatalf("DecryptMulti index = %d, want 0", index)
+	}
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Fatalf("DecryptMulti plaintext = %q, want %q", decrypted, plaintext)
+	}
+}
+
+func jweJSONWithoutProtectedHeader(t *testing.T, key []byte, plaintext []byte) string {
+	t.Helper()
+
+	cipher := newAESGCM(16)
+	parts, err := cipher.encrypt(key, []byte{}, plaintext)
+	if err != nil {
+		t.Fatalf("encrypt content: %v", err)
+	}
+
+	unprotected := rawHeader{}
+	err = unprotected.set(headerAlgorithm, DIRECT)
+	if err != nil {
+		t.Fatalf("set alg: %v", err)
+	}
+	err = unprotected.set(headerEncryption, A128GCM)
+	if err != nil {
+		t.Fatalf("set enc: %v", err)
+	}
+
+	raw := rawJSONWebEncryption{
+		Unprotected: &unprotected,
+		Iv:          newBuffer(parts.iv),
+		Ciphertext:  newBuffer(parts.ciphertext),
+		Tag:         newBuffer(parts.tag),
+	}
+	return string(mustSerializeJSON(raw))
+}
+
 func TestVectorsJWECorrupt(t *testing.T) {
 	priv := &rsa.PrivateKey{
 		PublicKey: rsa.PublicKey{


### PR DESCRIPTION
## Summary

Fixes #238.

This change handles JWE JSON Serialization inputs that decrypt successfully without a
protected header. The protected-header `zip` lookup now treats a nil protected header as
no compression value instead of dereferencing it after content decryption.

The fix preserves the existing protected-only `zip` rule and keeps successful
non-compressed decryptions unchanged.

## Verification

- `go test ./... -run '^TestJWEDecryptWithoutProtectedHeader$' -count=1 -v`
- `go test ./... -count=1`
- `go build ./...`
- `git diff --check`
