### PR TITLE
Bind protected JWS identity to verifier key

### DIFF
--- a/jws_test.go
+++ b/jws_test.go
@@ -17,6 +17,7 @@
 package jose
 
 import (
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
@@ -674,6 +675,109 @@ func TestJWSWithCertificateChain(t *testing.T) {
 		if !testCase.success && (len(chains) != 0 && err == nil) {
 			t.Fatalf("incorrectly verified certificate chain for test case %d (should fail)", i)
 		}
+	}
+}
+
+func TestVerifyRejectsProtectedKIDMismatchForDirectJWK(t *testing.T) {
+	payload := []byte("protected kid mismatch")
+	signer, err := NewSigner(
+		SigningKey{Algorithm: RS256, Key: rsaTestKey},
+		(&SignerOptions{}).WithHeader(headerKeyID, "victim"),
+	)
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	signed, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	parsed, err := ParseSigned(signed.FullSerialize(), []SignatureAlgorithm{RS256})
+	if err != nil {
+		t.Fatalf("ParseSigned: %v", err)
+	}
+
+	verifier := JSONWebKey{
+		Key:   &rsaTestKey.PublicKey,
+		KeyID: "attacker",
+	}
+	_, err = parsed.Verify(verifier)
+	if err == nil {
+		t.Fatal("Verify accepted a protected kid that differs from the verifier JWK kid")
+	}
+}
+
+func TestVerifyRejectsProtectedJWKMismatch(t *testing.T) {
+	victimKey, ok := testCertificates[0].PublicKey.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("test certificate key type = %T, want *rsa.PublicKey", testCertificates[0].PublicKey)
+	}
+
+	payload := []byte("protected jwk mismatch")
+	signer, err := NewSigner(
+		SigningKey{Algorithm: RS256, Key: rsaTestKey},
+		(&SignerOptions{}).WithHeader(headerJWK, JSONWebKey{Key: victimKey}),
+	)
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	signed, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	parsed, err := ParseSigned(signed.FullSerialize(), []SignatureAlgorithm{RS256})
+	if err != nil {
+		t.Fatalf("ParseSigned: %v", err)
+	}
+	_, err = parsed.Verify(&rsaTestKey.PublicKey)
+	if err == nil {
+		t.Fatal("Verify accepted protected JWK that differs from the verifier key")
+	}
+
+	signer, err = NewSigner(
+		SigningKey{Algorithm: RS256, Key: rsaTestKey},
+		(&SignerOptions{}).WithHeader(headerJWK, JSONWebKey{Key: &rsaTestKey.PublicKey}),
+	)
+	if err != nil {
+		t.Fatalf("NewSigner matching JWK: %v", err)
+	}
+	signed, err = signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("Sign matching JWK: %v", err)
+	}
+	parsed, err = ParseSigned(signed.FullSerialize(), []SignatureAlgorithm{RS256})
+	if err != nil {
+		t.Fatalf("ParseSigned matching JWK: %v", err)
+	}
+	verified, err := parsed.Verify(&rsaTestKey.PublicKey)
+	if err != nil {
+		t.Fatalf("Verify rejected matching protected JWK: %v", err)
+	}
+	if string(verified) != string(payload) {
+		t.Fatalf("verified payload = %q, want %q", verified, payload)
+	}
+}
+
+func TestVerifyRejectsProtectedX5CMismatch(t *testing.T) {
+	payload := []byte("protected x5c mismatch")
+	chain := []string{base64.StdEncoding.EncodeToString(testCertificates[0].Raw)}
+	signer, err := NewSigner(
+		SigningKey{Algorithm: RS256, Key: rsaTestKey},
+		(&SignerOptions{}).WithHeader(headerX5c, chain),
+	)
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	signed, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	parsed, err := ParseSigned(signed.FullSerialize(), []SignatureAlgorithm{RS256})
+	if err != nil {
+		t.Fatalf("ParseSigned: %v", err)
+	}
+	_, err = parsed.Verify(&rsaTestKey.PublicKey)
+	if err == nil {
+		t.Fatal("Verify accepted protected x5c that differs from the verifier key")
 	}
 }
 

--- a/signing.go
+++ b/signing.go
@@ -214,6 +214,82 @@ func newVerifier(verificationKey interface{}) (payloadVerifier, error) {
 	}
 }
 
+func validateVerifiedSignatureIdentity(verificationKey interface{}, signature Signature) error {
+	keyID := verificationKeyID(verificationKey)
+	if keyID != "" && signature.Protected.KeyID != "" && keyID != signature.Protected.KeyID {
+		return fmt.Errorf("go-jose/go-jose: protected kid does not match verification key")
+	}
+
+	hasProtectedJWK := signature.Protected.JSONWebKey != nil
+	hasProtectedX5c := len(signature.Protected.certificates) > 0
+	if !hasProtectedJWK && !hasProtectedX5c {
+		return nil
+	}
+
+	verifiedKey, ok := publicKeyForVerificationKey(verificationKey)
+	if !ok {
+		return fmt.Errorf("go-jose/go-jose: protected key identity cannot be bound to verification key")
+	}
+
+	if hasProtectedJWK && !publicKeysEqual(verifiedKey, signature.Protected.JSONWebKey.Key) {
+		return fmt.Errorf("go-jose/go-jose: protected jwk does not match verification key")
+	}
+	if hasProtectedX5c && !publicKeysEqual(verifiedKey, signature.Protected.certificates[0].PublicKey) {
+		return fmt.Errorf("go-jose/go-jose: protected x5c leaf does not match verification key")
+	}
+	return nil
+}
+
+func verificationKeyID(verificationKey interface{}) string {
+	switch key := verificationKey.(type) {
+	case JSONWebKey:
+		return key.KeyID
+	case *JSONWebKey:
+		if key == nil {
+			return ""
+		}
+		return key.KeyID
+	default:
+		return ""
+	}
+}
+
+func publicKeyForVerificationKey(verificationKey interface{}) (interface{}, bool) {
+	switch key := verificationKey.(type) {
+	case JSONWebKey:
+		return publicKeyForVerificationKey(key.Key)
+	case *JSONWebKey:
+		if key == nil {
+			return nil, false
+		}
+		return publicKeyForVerificationKey(key.Key)
+	case ed25519.PublicKey:
+		return key, true
+	case *rsa.PublicKey:
+		return key, true
+	case *ecdsa.PublicKey:
+		return key, true
+	default:
+		return nil, false
+	}
+}
+
+func publicKeysEqual(left interface{}, right interface{}) bool {
+	switch key := left.(type) {
+	case ed25519.PublicKey:
+		other, ok := right.(ed25519.PublicKey)
+		return ok && bytes.Equal(key, other)
+	case *rsa.PublicKey:
+		other, ok := right.(*rsa.PublicKey)
+		return ok && key.Equal(other)
+	case *ecdsa.PublicKey:
+		other, ok := right.(*ecdsa.PublicKey)
+		return ok && key.Equal(other)
+	default:
+		return false
+	}
+}
+
 func (ctx *genericSigner) addRecipient(alg SignatureAlgorithm, signingKey interface{}) error {
 	recipient, err := makeJWSRecipient(alg, signingKey)
 	if err != nil {
@@ -445,6 +521,10 @@ func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey inter
 	if err != nil {
 		return ErrCryptoFailure
 	}
+	err = validateVerifiedSignatureIdentity(key, signature)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -477,15 +557,6 @@ func (obj JSONWebSignature) VerifyMulti(verificationKey interface{}) (int, Signa
 // The verificationKey argument must have one of the types allowed for the
 // verificationKey argument of JSONWebSignature.Verify().
 func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey interface{}) (int, Signature, error) {
-	key, err := tryJWKS(verificationKey, obj.headers()...)
-	if err != nil {
-		return -1, Signature{}, err
-	}
-	verifier, err := newVerifier(key)
-	if err != nil {
-		return -1, Signature{}, err
-	}
-
 	for i, signature := range obj.Signatures {
 		if signature.header != nil {
 			// Per https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.11,
@@ -493,7 +564,7 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 			// "When used, this Header Parameter MUST be integrity
 			// protected; therefore, it MUST occur only within the JWS
 			// Protected Header."
-			err = signature.header.checkNoCritical()
+			err := signature.header.checkNoCritical()
 			if err != nil {
 				continue
 			}
@@ -501,7 +572,7 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 
 		if signature.protected != nil {
 			// Check for only supported critical headers
-			err = signature.protected.checkSupportedCritical(supportedCritical)
+			err := signature.protected.checkSupportedCritical(supportedCritical)
 			if err != nil {
 				continue
 			}
@@ -514,7 +585,19 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 
 		headers := signature.mergedHeaders()
 		alg := headers.getSignatureAlgorithm()
+		key, err := tryJWKS(verificationKey, signature.Header)
+		if err != nil {
+			continue
+		}
+		verifier, err := newVerifier(key)
+		if err != nil {
+			continue
+		}
 		err = verifier.verifyPayload(input, signature.Signature, alg)
+		if err != nil {
+			continue
+		}
+		err = validateVerifiedSignatureIdentity(key, signature)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## Summary

Fixes #241.

This patch binds protected JWS `kid`, `jwk`, and `x5c` identity material to the
key that successfully verifies the signature. The important behavior change is
that callers cannot authenticate a payload with one key while reading a
different protected key identity from the verified signature.

The implementation validates protected identity after cryptographic
verification, using the actual verification key selected directly or from a
JWKS. It preserves ordinary `kid` selection, embedded protected keys that match
the verifier, and signatures without protected key identity headers.

## Verification

- `go test ./... -count=1`
- `go build ./...`
- `gofmt -l signing.go jws_test.go`
- `git diff --check`
