### PR TITLE
jws: choose verification key per-signature

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -821,7 +821,7 @@ var (
 	ErrJWKSKidNotFound = errors.New("go-jose/go-jose: JWK with matching kid not found in JWK Set")
 )
 
-func tryJWKS(key interface{}, headers ...Header) (interface{}, error) {
+func tryJWKS(key interface{}, header Header) (interface{}, error) {
 	var jwks JSONWebKeySet
 
 	switch jwksType := key.(type) {
@@ -834,16 +834,8 @@ func tryJWKS(key interface{}, headers ...Header) (interface{}, error) {
 		return key, nil
 	}
 
-	// Determine the KID to search for from the headers.
-	var kid string
-	for _, header := range headers {
-		if header.KeyID != "" {
-			kid = header.KeyID
-			break
-		}
-	}
-
-	// If no KID is specified in the headers, reject.
+	// If no KID is specified in the header, reject.
+	kid := header.KeyID
 	if kid == "" {
 		return nil, ErrJWKSKidNotFound
 	}

--- a/signing.go
+++ b/signing.go
@@ -400,7 +400,13 @@ func (obj JSONWebSignature) UnsafePayloadWithoutVerification() []byte {
 // The verificationKey argument must have one of the types allowed for the
 // verificationKey argument of JSONWebSignature.Verify().
 func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey interface{}) error {
-	key, err := tryJWKS(verificationKey, obj.headers()...)
+	if len(obj.Signatures) > 1 {
+		return errors.New("go-jose/go-jose: too many signatures in payload; expecting only one")
+	}
+
+	signature := obj.Signatures[0]
+
+	key, err := tryJWKS(verificationKey, signature.Header)
 	if err != nil {
 		return err
 	}
@@ -408,12 +414,6 @@ func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey inter
 	if err != nil {
 		return err
 	}
-
-	if len(obj.Signatures) > 1 {
-		return errors.New("go-jose/go-jose: too many signatures in payload; expecting only one")
-	}
-
-	signature := obj.Signatures[0]
 
 	if signature.header != nil {
 		// Per https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.11,
@@ -477,15 +477,6 @@ func (obj JSONWebSignature) VerifyMulti(verificationKey interface{}) (int, Signa
 // The verificationKey argument must have one of the types allowed for the
 // verificationKey argument of JSONWebSignature.Verify().
 func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey interface{}) (int, Signature, error) {
-	key, err := tryJWKS(verificationKey, obj.headers()...)
-	if err != nil {
-		return -1, Signature{}, err
-	}
-	verifier, err := newVerifier(key)
-	if err != nil {
-		return -1, Signature{}, err
-	}
-
 	for i, signature := range obj.Signatures {
 		if signature.header != nil {
 			// Per https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.11,
@@ -493,7 +484,7 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 			// "When used, this Header Parameter MUST be integrity
 			// protected; therefore, it MUST occur only within the JWS
 			// Protected Header."
-			err = signature.header.checkNoCritical()
+			err := signature.header.checkNoCritical()
 			if err != nil {
 				continue
 			}
@@ -501,10 +492,24 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 
 		if signature.protected != nil {
 			// Check for only supported critical headers
-			err = signature.protected.checkSupportedCritical(supportedCritical)
+			err := signature.protected.checkSupportedCritical(supportedCritical)
 			if err != nil {
 				continue
 			}
+		}
+
+		// If the verification key is a JWK Set, pick a key based on this signature's
+		// "kid" header. On error, return immediately so we can provide ErrJWSKidNotFound
+		// instead of the more generic ErrCryptoFailure. This means we error on
+		// the first ErrJWSKidNotFound, even if a subsequent signature might succeed,
+		// which is not ideal but requires a little refactoring to fix.
+		key, err := tryJWKS(verificationKey, signature.Header)
+		if err != nil {
+			return -1, Signature{}, err
+		}
+		verifier, err := newVerifier(key)
+		if err != nil {
+			return -1, Signature{}, err
 		}
 
 		input, err := obj.computeAuthData(payload, &signature)
@@ -523,12 +528,4 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 	}
 
 	return -1, Signature{}, ErrCryptoFailure
-}
-
-func (obj JSONWebSignature) headers() []Header {
-	headers := make([]Header, len(obj.Signatures))
-	for i, sig := range obj.Signatures {
-		headers[i] = sig.Header
-	}
-	return headers
 }

--- a/signing_test.go
+++ b/signing_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -296,6 +297,99 @@ func TestMultiRecipientJWS(t *testing.T) {
 
 	if !bytes.Equal(output, input) {
 		t.Fatal("input/output do not match", output, input)
+	}
+}
+
+// TestVerifyMultiJWKSPerSignatureKid checks that VerifyMulti honors different "kid"
+// headers on different signatures. It creates a JWS that validates only if the "kid"
+// from the second of the two signatures is used.
+func TestVerifyMultiJWKSPerSignatureKid(t *testing.T) {
+	payload := []byte("Lorem ipsum dolor sit amet")
+
+	keyBar, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyFoo, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader) // only its public key goes in the JWKS
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Both signatures are produced by keyBar. The "foo" signature is therefore
+	// invalid relative to the JWKS, whose "foo" entry is the unrelated keyFoo.
+	signer, err := NewMultiSigner([]SigningKey{
+		{Algorithm: ES256, Key: &JSONWebKey{KeyID: "foo", Key: keyBar}},
+		{Algorithm: ES256, Key: &JSONWebKey{KeyID: "bar", Key: keyBar}},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseSigned(obj.FullSerialize(), []SignatureAlgorithm{ES256})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jwks := &JSONWebKeySet{Keys: []JSONWebKey{
+		{KeyID: "foo", Key: keyFoo.Public()},
+		{KeyID: "bar", Key: keyBar.Public()},
+	}}
+
+	idx, sig, out, err := parsed.VerifyMulti(jwks)
+	if err != nil {
+		t.Fatalf("VerifyMulti failed: %v", err)
+	}
+	if idx != 1 {
+		t.Errorf("verified signature index = %d, want 1", idx)
+	}
+	if sig.Header.KeyID != "bar" {
+		t.Errorf("verified kid = %q, want \"bar\"", sig.Header.KeyID)
+	}
+	if !bytes.Equal(out, payload) {
+		t.Error("payload mismatch")
+	}
+}
+
+// TestVerifyMultiJWKSNoMatchingKid checks that VerifyMulti against a JWK Set fails
+// with ErrJWKSKidNotFound when there's no key matching the "kid" headers of the
+// signatures.
+func TestVerifyMultiJWKSNoMatchingKid(t *testing.T) {
+	payload := []byte("Lorem ipsum dolor sit amet")
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := NewMultiSigner([]SigningKey{
+		{Algorithm: ES256, Key: &JSONWebKey{KeyID: "foo", Key: key}},
+		{Algorithm: ES256, Key: &JSONWebKey{KeyID: "bar", Key: key}},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseSigned(obj.FullSerialize(), []SignatureAlgorithm{ES256})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The JWKS contains a usable key, but under a kid that matches no signature.
+	jwks := &JSONWebKeySet{Keys: []JSONWebKey{
+		{KeyID: "other", Key: key.Public()},
+	}}
+
+	_, _, _, err = parsed.VerifyMulti(jwks)
+	if err == nil {
+		t.Fatal("expected error when no signature kid is present in the JWKS")
+	}
+	if !errors.Is(err, ErrJWKSKidNotFound) {
+		t.Errorf("got error %v, want ErrJWKSKidNotFound", err)
 	}
 }
 


### PR DESCRIPTION
When using a JWK Set, we look up the key to use based on a signature's "kid" header. Previously, we just chose based on the first signature's "kid" header, which was wrong.

Also, remove JSONWebSignature.headers(), which provided the headers from each of the signatures concatenated into a single list, which is never what we want.

Code and tests written by Claude. PR description and doc comments written by me.

Alternate approach to #241, #242.