### PR TITLE
Add tests to raise coverage of error and edge paths

### DIFF
--- a/coverage_asymmetric_test.go
+++ b/coverage_asymmetric_test.go
@@ -1,0 +1,108 @@
+/*-
+ * Copyright 2024 go-jose authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"testing"
+
+	"github.com/go-jose/go-jose/v4/json"
+)
+
+func epkHeader(t *testing.T, key interface{}) *json.RawMessage {
+	t.Helper()
+	b, err := (&JSONWebKey{Key: key}).MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return makeRawMessage(b)
+}
+
+func TestAsymmetricUnsupportedAlgBranches(t *testing.T) {
+	// RSA verifyPayload, unsupported alg.
+	rv := rsaEncrypterVerifier{publicKey: &rsaTestKey.PublicKey}
+	if err := rv.verifyPayload(nil, nil, "BOGUS"); err != ErrUnsupportedAlgorithm {
+		t.Errorf("rsa verifyPayload bad alg = %v", err)
+	}
+
+	// EC encryptKey, unsupported alg.
+	ev := ecEncrypterVerifier{publicKey: &ecTestKey256.PublicKey}
+	if _, err := ev.encryptKey(nil, "BOGUS"); err != ErrUnsupportedAlgorithm {
+		t.Errorf("ec encryptKey bad alg = %v", err)
+	}
+
+	// Ed25519 signPayload / verifyPayload.
+	eds := edDecrypterSigner{privateKey: ed25519PrivateKey}
+	if _, err := eds.signPayload(nil, "BOGUS"); err != ErrUnsupportedAlgorithm {
+		t.Errorf("ed signPayload bad alg = %v", err)
+	}
+	edv := edEncrypterVerifier{publicKey: ed25519PublicKey}
+	if err := edv.verifyPayload(nil, nil, "BOGUS"); err != ErrUnsupportedAlgorithm {
+		t.Errorf("ed verifyPayload bad alg = %v", err)
+	}
+	if err := edv.verifyPayload([]byte("x"), make([]byte, 64), EdDSA); err == nil {
+		t.Error("ed verifyPayload with bad signature: expected error")
+	}
+
+	// EC signPayload: bit-size mismatch and unsupported alg (size 0 != curve).
+	es := ecDecrypterSigner{privateKey: ecTestKey256}
+	if _, err := es.signPayload([]byte("x"), ES384); err == nil {
+		t.Error("ec signPayload with mismatched curve: expected error")
+	}
+	if _, err := es.signPayload([]byte("x"), "BOGUS"); err == nil {
+		t.Error("ec signPayload with unsupported alg: expected error")
+	}
+}
+
+func TestECDecryptKeyErrorBranches(t *testing.T) {
+	ds := ecDecrypterSigner{privateKey: ecTestKey256}
+	rec := &recipientInfo{encryptedKey: []byte("x")}
+
+	// nil recipient
+	if _, err := ds.decryptKey(rawHeader{}, nil, nil); err == nil {
+		t.Error("decryptKey nil recipient: expected error")
+	}
+	// invalid epk header (not a JWK)
+	if _, err := ds.decryptKey(rawHeader{headerEPK: rawMsg(`5`)}, rec, nil); err == nil {
+		t.Error("decryptKey invalid epk: expected error")
+	}
+	// missing epk header
+	if _, err := ds.decryptKey(rawHeader{}, rec, nil); err == nil {
+		t.Error("decryptKey missing epk: expected error")
+	}
+	// epk present but not an EC key
+	if _, err := ds.decryptKey(rawHeader{headerEPK: epkHeader(t, &rsaTestKey.PublicKey)}, rec, nil); err == nil {
+		t.Error("decryptKey non-EC epk: expected error")
+	}
+	// epk on a different curve -> not on this private key's curve
+	if _, err := ds.decryptKey(rawHeader{headerEPK: epkHeader(t, &ecTestKey384.PublicKey)}, rec, nil); err == nil {
+		t.Error("decryptKey cross-curve epk: expected error")
+	}
+	// valid epk, malformed apu / apv
+	good := epkHeader(t, &ecTestKey256.PublicKey)
+	if _, err := ds.decryptKey(rawHeader{headerEPK: good, headerAPU: rawMsg(`5`)}, rec, nil); err == nil {
+		t.Error("decryptKey invalid apu: expected error")
+	}
+	if _, err := ds.decryptKey(rawHeader{headerEPK: good, headerAPV: rawMsg(`5`)}, rec, nil); err == nil {
+		t.Error("decryptKey invalid apv: expected error")
+	}
+}
+
+func TestGetPbkdf2ParamsPanic(t *testing.T) {
+	mustPanic(t, "getPbkdf2Params unsupported alg", func() {
+		getPbkdf2Params("BOGUS")
+	})
+}

--- a/coverage_crypter_test.go
+++ b/coverage_crypter_test.go
@@ -1,0 +1,154 @@
+/*-
+ * Copyright 2024 go-jose authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"testing"
+)
+
+// A two-recipient JWE in JSON serialization.
+const covMultiRecipientJWE = `{"protected":"eyJlbmMiOiJBMTI4R0NNIn0",` +
+	`"recipients":[{"header":{"alg":"A128KW"},"encrypted_key":"AAAA"},` +
+	`{"header":{"alg":"A256KW"},"encrypted_key":"BBBB"}],` +
+	`"iv":"AAAA","ciphertext":"AAAA","tag":"AAAA"}`
+
+// A single-recipient JWE whose protected header carries a "crit" parameter.
+const covCritJWE = `{"protected":"eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIiwiY3JpdCI6WyJ4Il19",` +
+	`"iv":"AAAA","ciphertext":"AAAA","tag":"AAAA"}`
+
+// A single-recipient JWE naming a content encryption with no cipher.
+const covBogusEncJWE = `{"protected":"eyJhbGciOiJkaXIiLCJlbmMiOiJCT0dVUyJ9",` +
+	`"iv":"AAAA","ciphertext":"AAAA","tag":"AAAA"}`
+
+// A well-formed single-recipient dir/A128GCM JWE (decryption fails on the tag).
+const covDirJWE = `{"protected":"eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0",` +
+	`"iv":"AAAA","ciphertext":"AAAA","tag":"AAAA"}`
+
+func parseJWE(t *testing.T, s string, enc ...ContentEncryption) *JSONWebEncryption {
+	t.Helper()
+	if len(enc) == 0 {
+		enc = []ContentEncryption{A128GCM}
+	}
+	obj, err := ParseEncryptedJSON(s, []KeyAlgorithm{DIRECT, A128KW, A256KW}, enc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return obj
+}
+
+func TestDecryptErrorBranches(t *testing.T) {
+	key := make([]byte, 16)
+
+	// More than one recipient.
+	if _, err := parseJWE(t, covMultiRecipientJWE).Decrypt(key); err == nil {
+		t.Error("Decrypt with multiple recipients: expected error")
+	}
+	// "crit" present -> checkNoCritical.
+	if _, err := parseJWE(t, covCritJWE).Decrypt(key); err == nil {
+		t.Error("Decrypt with crit header: expected error")
+	}
+	// Unsupported key type -> newDecrypter error.
+	if _, err := parseJWE(t, covDirJWE).Decrypt("not-a-key"); err == nil {
+		t.Error("Decrypt with bad key type: expected error")
+	}
+	// Unsupported content encryption -> nil cipher.
+	if _, err := parseJWE(t, covBogusEncJWE, "BOGUS").Decrypt(key); err == nil {
+		t.Error("Decrypt with unsupported enc: expected error")
+	}
+	// Valid structure, wrong/short key material -> ErrCryptoFailure.
+	if _, err := parseJWE(t, covDirJWE).Decrypt(key); err == nil {
+		t.Error("Decrypt of corrupt ciphertext: expected error")
+	}
+}
+
+func TestNewMultiEncrypterBranches(t *testing.T) {
+	aesKey := make([]byte, 16)
+
+	// Unsupported content encryption -> nil cipher.
+	if _, err := NewMultiEncrypter("BOGUS", []Recipient{{Algorithm: A128KW, Key: aesKey}}, nil); err == nil {
+		t.Error("NewMultiEncrypter with bad enc: expected error")
+	}
+	// No recipients.
+	if _, err := NewMultiEncrypter(A128GCM, nil, nil); err == nil {
+		t.Error("NewMultiEncrypter with no recipients: expected error")
+	}
+	// DIRECT is not allowed in multi-recipient mode -> addRecipient error.
+	if _, err := NewMultiEncrypter(A128GCM, []Recipient{{Algorithm: DIRECT, Key: aesKey}}, nil); err == nil {
+		t.Error("NewMultiEncrypter with DIRECT: expected error")
+	}
+	// Unsupported key type -> makeJWERecipient error.
+	if _, err := NewMultiEncrypter(A128GCM, []Recipient{{Algorithm: A128KW, Key: 12345}}, nil); err == nil {
+		t.Error("NewMultiEncrypter with bad key type: expected error")
+	}
+
+	// PBES2 recipient exercises the p2c/p2s assignment branch in addRecipient.
+	enc, err := NewMultiEncrypter(A128GCM, []Recipient{{
+		Algorithm:  PBES2_HS256_A128KW,
+		Key:        []byte("password"),
+		PBES2Count: 4096,
+		PBES2Salt:  make([]byte, 16),
+	}}, nil)
+	if err != nil {
+		t.Fatalf("NewMultiEncrypter PBES2: %v", err)
+	}
+	if _, err := enc.Encrypt([]byte("hi")); err != nil {
+		t.Fatalf("Encrypt PBES2: %v", err)
+	}
+}
+
+func TestEncryptDecryptWithJWKKey(t *testing.T) {
+	// JSONWebKey (value and pointer) routing in makeJWERecipient and newDecrypter.
+	aesKey := make([]byte, 16)
+	jwk := JSONWebKey{Key: aesKey, KeyID: "k1"}
+
+	enc, err := NewEncrypter(A128GCM, Recipient{Algorithm: A128KW, Key: jwk}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := enc.Encrypt([]byte("secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := obj.Decrypt(&jwk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != "secret" {
+		t.Errorf("decrypt = %q, want secret", out)
+	}
+}
+
+func TestDecryptMultiErrorBranches(t *testing.T) {
+	key := make([]byte, 16)
+
+	// "crit" present -> checkNoCritical.
+	if _, _, _, err := parseJWE(t, covCritJWE).DecryptMulti(key); err == nil {
+		t.Error("DecryptMulti with crit header: expected error")
+	}
+	// Unsupported key type -> newDecrypter error.
+	if _, _, _, err := parseJWE(t, covDirJWE).DecryptMulti("not-a-key"); err == nil {
+		t.Error("DecryptMulti with bad key type: expected error")
+	}
+	// Unsupported content encryption -> nil cipher.
+	if _, _, _, err := parseJWE(t, covBogusEncJWE, "BOGUS").DecryptMulti(key); err == nil {
+		t.Error("DecryptMulti with unsupported enc: expected error")
+	}
+	// No recipient can decrypt -> error.
+	if _, _, _, err := parseJWE(t, covMultiRecipientJWE).DecryptMulti(make([]byte, 16)); err == nil {
+		t.Error("DecryptMulti with no working recipient: expected error")
+	}
+}

--- a/coverage_internal_test.go
+++ b/coverage_internal_test.go
@@ -1,0 +1,283 @@
+/*-
+ * Copyright 2024 go-jose authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4/json"
+)
+
+// rawMsg builds a rawHeader from raw JSON fragments, exercising the internal
+// header getters' error and edge branches directly.
+func rawMsg(s string) *json.RawMessage {
+	return makeRawMessage([]byte(s))
+}
+
+func TestErrUnexpectedSignatureAlgorithmError(t *testing.T) {
+	e := &ErrUnexpectedSignatureAlgorithm{Got: HS256, expected: []SignatureAlgorithm{RS256}}
+	if e.Error() == "" {
+		t.Error("expected non-empty error string")
+	}
+}
+
+func TestRawHeaderGettersErrorBranches(t *testing.T) {
+	// getString: non-string value returns ""
+	if s := (rawHeader{headerNonce: rawMsg(`5`)}).getNonce(); s != "" {
+		t.Errorf("getNonce on number = %q, want \"\"", s)
+	}
+	// getString on a valid string
+	if s := (rawHeader{headerNonce: rawMsg(`"abc"`)}).getNonce(); s != "abc" {
+		t.Errorf("getNonce = %q, want abc", s)
+	}
+
+	// getByteBuffer error branch (via getAPU/getIV/getP2S/getTag/getAPV)
+	for name, h := range map[string]rawHeader{
+		"apu": {headerAPU: rawMsg(`5`)},
+		"apv": {headerAPV: rawMsg(`5`)},
+		"iv":  {headerIV: rawMsg(`5`)},
+		"tag": {headerTag: rawMsg(`5`)},
+		"p2s": {headerP2S: rawMsg(`5`)},
+	} {
+		var err error
+		switch name {
+		case "apu":
+			_, err = h.getAPU()
+		case "apv":
+			_, err = h.getAPV()
+		case "iv":
+			_, err = h.getIV()
+		case "tag":
+			_, err = h.getTag()
+		case "p2s":
+			_, err = h.getP2S()
+		}
+		if err == nil {
+			t.Errorf("get %s on number: expected error", name)
+		}
+	}
+	// nil byteBuffer returns (nil, nil)
+	if bb, err := (rawHeader{}).getAPU(); bb != nil || err != nil {
+		t.Errorf("getAPU absent = (%v,%v), want (nil,nil)", bb, err)
+	}
+
+	// getEPK / getJWK error and nil branches
+	if _, err := (rawHeader{headerEPK: rawMsg(`5`)}).getEPK(); err == nil {
+		t.Error("getEPK on number: expected error")
+	}
+	if epk, err := (rawHeader{}).getEPK(); epk != nil || err != nil {
+		t.Errorf("getEPK absent = (%v,%v), want (nil,nil)", epk, err)
+	}
+	if _, err := (rawHeader{headerJWK: rawMsg(`5`)}).getJWK(); err == nil {
+		t.Error("getJWK on number: expected error")
+	}
+	if jwk, err := (rawHeader{}).getJWK(); jwk != nil || err != nil {
+		t.Errorf("getJWK absent = (%v,%v), want (nil,nil)", jwk, err)
+	}
+
+	// getCritical error, nil, and value branches
+	if _, err := (rawHeader{headerCritical: rawMsg(`5`)}).getCritical(); err == nil {
+		t.Error("getCritical on number: expected error")
+	}
+	if c, err := (rawHeader{}).getCritical(); c != nil || err != nil {
+		t.Errorf("getCritical absent = (%v,%v), want (nil,nil)", c, err)
+	}
+
+	// getP2C error, nil, value
+	if _, err := (rawHeader{headerP2C: rawMsg(`"x"`)}).getP2C(); err == nil {
+		t.Error("getP2C on string: expected error")
+	}
+	if v, err := (rawHeader{}).getP2C(); v != 0 || err != nil {
+		t.Errorf("getP2C absent = (%v,%v), want (0,nil)", v, err)
+	}
+	if v, err := (rawHeader{headerP2C: rawMsg(`42`)}).getP2C(); v != 42 || err != nil {
+		t.Errorf("getP2C = (%v,%v), want (42,nil)", v, err)
+	}
+
+	// getB64 error, nil (default true), value
+	if _, err := (rawHeader{headerB64: rawMsg(`"x"`)}).getB64(); err == nil {
+		t.Error("getB64 on string: expected error")
+	}
+	if v, err := (rawHeader{}).getB64(); !v || err != nil {
+		t.Errorf("getB64 absent = (%v,%v), want (true,nil)", v, err)
+	}
+	if v, err := (rawHeader{headerB64: rawMsg(`false`)}).getB64(); v || err != nil {
+		t.Errorf("getB64 = (%v,%v), want (false,nil)", v, err)
+	}
+}
+
+func TestRawHeaderIsSet(t *testing.T) {
+	cases := []struct {
+		name string
+		h    rawHeader
+		want bool
+	}{
+		{"absent", rawHeader{}, false},
+		{"nil value", rawHeader{headerNonce: nil}, false},
+		{"invalid json", rawHeader{headerNonce: rawMsg(`{`)}, true},
+		{"empty string", rawHeader{headerNonce: rawMsg(`""`)}, false},
+		{"non-empty string", rawHeader{headerNonce: rawMsg(`"x"`)}, true},
+		{"number", rawHeader{headerNonce: rawMsg(`5`)}, true},
+	}
+	for _, c := range cases {
+		if got := c.h.isSet(headerNonce); got != c.want {
+			t.Errorf("isSet(%s) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestRawHeaderSetAndMerge(t *testing.T) {
+	// set error branch: a channel cannot be marshaled to JSON
+	h := rawHeader{}
+	if err := h.set(headerNonce, make(chan int)); err == nil {
+		t.Error("set with unmarshalable value: expected error")
+	}
+	// set happy path
+	if err := h.set(headerKeyID, "kid"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	// merge: src nil is a no-op; an already-set key is skipped, a new one copied
+	dst := rawHeader{headerAlgorithm: rawMsg(`"RS256"`)}
+	dst.merge(nil)
+	src := &rawHeader{
+		headerAlgorithm: rawMsg(`"HS256"`), // already set -> skipped
+		headerKeyID:     rawMsg(`"k"`),     // new -> copied
+	}
+	dst.merge(src)
+	if dst.getString(headerAlgorithm) != "RS256" {
+		t.Error("merge overwrote an already-set header")
+	}
+	if dst.getString(headerKeyID) != "k" {
+		t.Error("merge did not copy a new header")
+	}
+}
+
+func TestRawHeaderSanitizedErrorBranches(t *testing.T) {
+	cases := map[string]rawHeader{
+		"jwk":            {headerJWK: rawMsg(`5`)},
+		"kid":            {headerKeyID: rawMsg(`5`)},
+		"alg":            {headerAlgorithm: rawMsg(`5`)},
+		"nonce":          {headerNonce: rawMsg(`5`)},
+		"x5c notarray":   {headerX5c: rawMsg(`5`)},
+		"x5c bad base64": {headerX5c: rawMsg(`["!"]`)},
+		"x5c bad cert":   {headerX5c: rawMsg(`["QQ"]`)},
+		"extra":          {"custom": rawMsg(`{`)},
+	}
+	for name, h := range cases {
+		if _, err := h.sanitized(); err == nil {
+			t.Errorf("sanitized(%s): expected error", name)
+		}
+	}
+
+	// nil value is skipped; a valid extra header is collected
+	h, err := rawHeader{
+		headerNonce: nil,
+		"custom":    rawMsg(`"v"`),
+	}.sanitized()
+	if err != nil {
+		t.Fatalf("sanitized valid: %v", err)
+	}
+	if h.ExtraHeaders["custom"] != "v" {
+		t.Errorf("ExtraHeaders[custom] = %v, want v", h.ExtraHeaders["custom"])
+	}
+}
+
+func TestParseCertificateChainErrors(t *testing.T) {
+	if _, err := parseCertificateChain([]string{"!"}); err == nil {
+		t.Error("parseCertificateChain with invalid base64: expected error")
+	}
+	if _, err := parseCertificateChain([]string{"QQ"}); err == nil {
+		t.Error("parseCertificateChain with non-certificate bytes: expected error")
+	}
+}
+
+func TestRecipientConstructorErrorBranches(t *testing.T) {
+	// Unsupported algorithm and nil-key branches in the recipient/signer constructors.
+	if _, err := newRSARecipient("bogus", &rsa.PublicKey{}); err != ErrUnsupportedAlgorithm {
+		t.Errorf("newRSARecipient bad alg = %v, want ErrUnsupportedAlgorithm", err)
+	}
+	if _, err := newRSARecipient(RSA1_5, nil); err == nil {
+		t.Error("newRSARecipient nil key: expected error")
+	}
+	if _, err := newRSASigner("bogus", &rsa.PrivateKey{}); err != ErrUnsupportedAlgorithm {
+		t.Errorf("newRSASigner bad alg = %v, want ErrUnsupportedAlgorithm", err)
+	}
+	if _, err := newRSASigner(RS256, nil); err == nil {
+		t.Error("newRSASigner nil key: expected error")
+	}
+	if _, err := newEd25519Signer("bogus", nil); err != ErrUnsupportedAlgorithm {
+		t.Errorf("newEd25519Signer bad alg = %v, want ErrUnsupportedAlgorithm", err)
+	}
+	if _, err := newEd25519Signer(EdDSA, nil); err == nil {
+		t.Error("newEd25519Signer nil key: expected error")
+	}
+	if _, err := newECDHRecipient("bogus", &ecdsa.PublicKey{}); err != ErrUnsupportedAlgorithm {
+		t.Errorf("newECDHRecipient bad alg = %v, want ErrUnsupportedAlgorithm", err)
+	}
+	if _, err := newECDHRecipient(ECDH_ES, nil); err == nil {
+		t.Error("newECDHRecipient nil key: expected error")
+	}
+	if _, err := newECDSASigner("bogus", &ecdsa.PrivateKey{}); err != ErrUnsupportedAlgorithm {
+		t.Errorf("newECDSASigner bad alg = %v, want ErrUnsupportedAlgorithm", err)
+	}
+	if _, err := newECDSASigner(ES256, nil); err == nil {
+		t.Error("newECDSASigner nil key: expected error")
+	}
+}
+
+func TestMustSerializeJSONPanics(t *testing.T) {
+	// nil pointer serializes to "null", which the function rejects
+	mustPanic(t, "nil pointer", func() {
+		var p *JSONWebKey
+		mustSerializeJSON(p)
+	})
+	// a value that cannot be marshaled at all
+	mustPanic(t, "marshal error", func() {
+		mustSerializeJSON(make(chan int))
+	})
+}
+
+func TestBase64JoinWithDotsEmpty(t *testing.T) {
+	if s := base64JoinWithDots(); s != "" {
+		t.Errorf("base64JoinWithDots() = %q, want empty", s)
+	}
+}
+
+func TestByteBufferUnmarshalBranches(t *testing.T) {
+	// empty string decodes to a nil buffer without error
+	var b byteBuffer
+	if err := b.UnmarshalJSON([]byte(`""`)); err != nil {
+		t.Errorf("UnmarshalJSON empty: %v", err)
+	}
+	// invalid base64 is an error
+	if err := b.UnmarshalJSON([]byte(`"!!!!"`)); err == nil {
+		t.Error("UnmarshalJSON invalid base64: expected error")
+	}
+}
+
+func mustPanic(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Errorf("%s: expected panic", name)
+		}
+	}()
+	fn()
+}

--- a/coverage_jwk_test.go
+++ b/coverage_jwk_test.go
@@ -1,0 +1,183 @@
+/*-
+ * Copyright 2024 go-jose authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"math/big"
+	"testing"
+)
+
+// thumbprintOpaqueSigner is a minimal OpaqueSigner whose Public() returns a JWK
+// wrapping a concrete public key, so Thumbprint's OpaqueSigner branch resolves.
+type thumbprintOpaqueSigner struct{}
+
+func (thumbprintOpaqueSigner) Public() *JSONWebKey {
+	return &JSONWebKey{Key: &rsaTestKey.PublicKey}
+}
+func (thumbprintOpaqueSigner) Algs() []SignatureAlgorithm { return []SignatureAlgorithm{RS256} }
+func (thumbprintOpaqueSigner) SignPayload([]byte, SignatureAlgorithm) ([]byte, error) {
+	return nil, nil
+}
+
+func TestThumbprintAllKeyTypes(t *testing.T) {
+	keys := map[string]interface{}{
+		"ed25519 public":  ed25519PublicKey,
+		"ed25519 private": ed25519PrivateKey,
+		"ecdsa public":    &ecTestKey256.PublicKey,
+		"ecdsa private":   ecTestKey256,
+		"rsa public":      &rsaTestKey.PublicKey,
+		"rsa private":     rsaTestKey,
+		"opaque signer":   thumbprintOpaqueSigner{},
+	}
+	for name, key := range keys {
+		jwk := &JSONWebKey{Key: key}
+		if _, err := jwk.Thumbprint(crypto.SHA256); err != nil {
+			t.Errorf("Thumbprint(%s): %v", name, err)
+		}
+	}
+
+	// Unknown key type -> default error branch
+	if _, err := (&JSONWebKey{Key: "not-a-key"}).Thumbprint(crypto.SHA256); err == nil {
+		t.Error("Thumbprint of unknown key type: expected error")
+	}
+}
+
+func TestThumbprintInputErrorBranches(t *testing.T) {
+	// ecThumbprintInput: coordinate larger than the curve size
+	tooBig := new(big.Int).Lsh(big.NewInt(1), 8*40) // 41 bytes, > P-256's 32
+	if _, err := ecThumbprintInput(elliptic.P256(), tooBig, big.NewInt(1)); err == nil {
+		t.Error("ecThumbprintInput with oversized x: expected error")
+	}
+	// edThumbprintInput: key longer than 32 bytes
+	if _, err := edThumbprintInput(make(ed25519.PublicKey, 33)); err == nil {
+		t.Error("edThumbprintInput with oversized key: expected error")
+	}
+}
+
+func TestJSONWebKeyValid(t *testing.T) {
+	cases := []struct {
+		name string
+		key  interface{}
+		want bool
+	}{
+		{"nil", nil, false},
+		{"ecdsa public valid", &ecTestKey256.PublicKey, true},
+		{"ecdsa public nil curve", &ecdsa.PublicKey{}, false},
+		{"ecdsa private valid", ecTestKey256, true},
+		{"ecdsa private incomplete", &ecdsa.PrivateKey{}, false},
+		{"rsa public valid", &rsaTestKey.PublicKey, true},
+		{"rsa public zero e", &rsa.PublicKey{N: big.NewInt(1)}, false},
+		{"rsa private valid", rsaTestKey, true},
+		{"rsa private incomplete", &rsa.PrivateKey{}, false},
+		{"ed public valid", ed25519PublicKey, true},
+		{"ed public wrong len", ed25519.PublicKey(make([]byte, 5)), false},
+		{"ed private valid", ed25519PrivateKey, true},
+		{"ed private wrong len", ed25519.PrivateKey(make([]byte, 5)), false},
+		{"unknown", "not-a-key", false},
+	}
+	for _, c := range cases {
+		if got := (&JSONWebKey{Key: c.key}).Valid(); got != c.want {
+			t.Errorf("Valid(%s) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestJSONWebKeyUnmarshalErrorBranches(t *testing.T) {
+	bad := []string{
+		`{"kty":"oct","k":"AA","x5c":["!"]}`,       // x5c parse error
+		`{"kty":"OKP","crv":"Ed25519","d":"AA"}`,   // ed private missing X
+		`{"kty":"OKP","crv":"Ed25519"}`,            // ed public missing X
+		`{"kty":"oct","k":"AA","x5t":"!"}`,         // x5t invalid base64
+		`{"kty":"oct","k":"AA","x5t#S256":"!"}`,    // x5t#S256 invalid base64
+		`{"kty":"oct","k":"AA","x5t":"AAAA"}`,      // x5t wrong size
+		`{"kty":"oct","k":"AA","x5t#S256":"AAAA"}`, // x5t#S256 wrong size
+		`{"kty":"EC","crv":"P-256","d":"AA"}`,      // ec private missing coords
+	}
+	for _, s := range bad {
+		var k JSONWebKey
+		if err := k.UnmarshalJSON([]byte(s)); err == nil {
+			t.Errorf("UnmarshalJSON(%s): expected error", s)
+		}
+	}
+}
+
+func TestJSONWebKeyMarshalThumbprintErrors(t *testing.T) {
+	if _, err := (&JSONWebKey{
+		Key:                       &rsaTestKey.PublicKey,
+		CertificateThumbprintSHA1: []byte("too-short"),
+	}).MarshalJSON(); err == nil {
+		t.Error("MarshalJSON with bad SHA-1 thumbprint: expected error")
+	}
+	if _, err := (&JSONWebKey{
+		Key:                         &rsaTestKey.PublicKey,
+		CertificateThumbprintSHA256: []byte("too-short"),
+	}).MarshalJSON(); err == nil {
+		t.Error("MarshalJSON with bad SHA-256 thumbprint: expected error")
+	}
+}
+
+func TestTryJWKSBranches(t *testing.T) {
+	// Non-JWKS key is returned unchanged.
+	if got, err := tryJWKS(covHMACKey1, Header{}); err != nil || got == nil {
+		t.Errorf("tryJWKS non-JWKS = (%v,%v)", got, err)
+	}
+	// JWKS by value, no kid in header -> rejected.
+	if _, err := tryJWKS(JSONWebKeySet{}, Header{}); err == nil {
+		t.Error("tryJWKS with no kid: expected error")
+	}
+	// JWKS by pointer, kid not present -> rejected.
+	set := &JSONWebKeySet{Keys: []JSONWebKey{{KeyID: "a", Key: &rsaTestKey.PublicKey}}}
+	if _, err := tryJWKS(set, Header{KeyID: "missing"}); err == nil {
+		t.Error("tryJWKS with unknown kid: expected error")
+	}
+	// JWKS by pointer, matching kid -> returns the key.
+	if got, err := tryJWKS(set, Header{KeyID: "a"}); err != nil || got == nil {
+		t.Errorf("tryJWKS matching kid = (%v,%v)", got, err)
+	}
+}
+
+func TestJSONWebKeyPublic(t *testing.T) {
+	// Private keys -> their public halves.
+	for name, key := range map[string]interface{}{
+		"ecdsa":   ecTestKey256,
+		"rsa":     rsaTestKey,
+		"ed25519": ed25519PrivateKey,
+	} {
+		pub := (&JSONWebKey{Key: key}).Public()
+		if !pub.IsPublic() {
+			t.Errorf("Public(%s) did not return a public key", name)
+		}
+	}
+
+	// Already-public key -> returned unchanged.
+	pubIn := &JSONWebKey{Key: &rsaTestKey.PublicKey}
+	pubOut := pubIn.Public()
+	if !pubOut.IsPublic() {
+		t.Error("Public() of a public key should stay public")
+	}
+
+	// Non-asymmetric key -> empty (invalid) key from the default branch.
+	empty := (&JSONWebKey{Key: []byte("symmetric")}).Public()
+	if empty.Key != nil {
+		t.Errorf("Public() of symmetric key = %v, want empty", empty.Key)
+	}
+}

--- a/coverage_jws_test.go
+++ b/coverage_jws_test.go
@@ -1,0 +1,83 @@
+/*-
+ * Copyright 2024 go-jose authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"testing"
+)
+
+func TestJWSParseErrorBranches(t *testing.T) {
+	algs := []SignatureAlgorithm{HS256}
+
+	// Empty signature-algorithm list.
+	if _, err := ParseSignedJSON(`{"payload":"dGVzdA","protected":"eyJhbGciOiJIUzI1NiJ9","signature":"AAAA"}`, nil); err == nil {
+		t.Error("ParseSignedJSON with no algorithms: expected error")
+	}
+
+	jsonCases := map[string]string{
+		// flattened: protected header field of wrong type (kid as number)
+		"flattened bad kid": `{"payload":"dGVzdA","protected":"eyJhbGciOiJIUzI1NiIsImtpZCI6NX0","signature":"AAAA"}`,
+		// signatures array: protected decodes to "{" which is invalid header JSON
+		"array bad protected json": `{"payload":"dGVzdA","signatures":[{"protected":"ew","signature":"AAAA"}]}`,
+		// signatures array: embedded jwk is a non-public (symmetric) key
+		"array non-public jwk": `{"payload":"dGVzdA","signatures":[{"protected":"eyJhbGciOiJIUzI1NiIsImp3ayI6eyJrdHkiOiJvY3QiLCJrIjoiQUEifX0","signature":"AAAA"}]}`,
+	}
+	for name, s := range jsonCases {
+		if _, err := ParseSignedJSON(s, algs); err == nil {
+			t.Errorf("ParseSignedJSON(%s): expected error", name)
+		}
+	}
+
+	// ParseSignedCompact wrapper: malformed compact token.
+	if _, err := ParseSignedCompact("only.two", algs); err == nil {
+		t.Error("ParseSignedCompact with too few parts: expected error")
+	}
+	// ParseSignedCompact: protected segment is not valid base64url.
+	if _, err := ParseSignedCompact("!.AAAA.AAAA", algs); err == nil {
+		t.Error("ParseSignedCompact with bad base64: expected error")
+	}
+}
+
+func TestCheckSupportedCriticalError(t *testing.T) {
+	// getCritical returns an error (crit is not an array), propagated out.
+	h := rawHeader{headerCritical: rawMsg(`5`)}
+	if err := h.checkSupportedCritical(supportedCritical); err == nil {
+		t.Error("checkSupportedCritical with malformed crit: expected error")
+	}
+}
+
+func TestVerifyWithJWKKey(t *testing.T) {
+	// newVerifier's JSONWebKey and *JSONWebKey recursion branches.
+	signer, err := NewSigner(SigningKey{Algorithm: HS256, Key: covHMACKey1}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := signer.Sign([]byte("payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseSigned(obj.FullSerialize(), []SignatureAlgorithm{HS256})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parsed.Verify(JSONWebKey{Key: covHMACKey1}); err != nil {
+		t.Errorf("Verify with JSONWebKey value: %v", err)
+	}
+	if _, err := parsed.Verify(&JSONWebKey{Key: covHMACKey1}); err != nil {
+		t.Errorf("Verify with *JSONWebKey: %v", err)
+	}
+}

--- a/coverage_misc_test.go
+++ b/coverage_misc_test.go
@@ -1,0 +1,103 @@
+/*-
+ * Copyright 2024 go-jose authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"testing"
+)
+
+func TestJWEContainsAndValidateAlgEnc(t *testing.T) {
+	// "not found" branches of the membership helpers.
+	if containsKeyAlgorithm([]KeyAlgorithm{A128KW}, RSA1_5) {
+		t.Error("containsKeyAlgorithm reported a missing algorithm as present")
+	}
+	if containsContentEncryption([]ContentEncryption{A128GCM}, A256GCM) {
+		t.Error("containsContentEncryption reported a missing algorithm as present")
+	}
+
+	// validateAlgEnc: alg mismatch, enc mismatch, and the all-good path.
+	good := rawHeader{headerAlgorithm: rawMsg(`"dir"`), headerEncryption: rawMsg(`"A128GCM"`)}
+	if err := validateAlgEnc(good, []KeyAlgorithm{DIRECT}, []ContentEncryption{A128GCM}); err != nil {
+		t.Errorf("validateAlgEnc valid = %v", err)
+	}
+	if err := validateAlgEnc(good, []KeyAlgorithm{A128KW}, []ContentEncryption{A128GCM}); err == nil {
+		t.Error("validateAlgEnc with disallowed alg: expected error")
+	}
+	if err := validateAlgEnc(good, []KeyAlgorithm{DIRECT}, []ContentEncryption{A256GCM}); err == nil {
+		t.Error("validateAlgEnc with disallowed enc: expected error")
+	}
+}
+
+func TestParseEncryptedEmptyAlgLists(t *testing.T) {
+	if _, err := ParseEncryptedJSON(covDirJWE, nil, []ContentEncryption{A128GCM}); err == nil {
+		t.Error("ParseEncryptedJSON with no key algorithms: expected error")
+	}
+	if _, err := ParseEncryptedJSON(covDirJWE, []KeyAlgorithm{DIRECT}, nil); err == nil {
+		t.Error("ParseEncryptedJSON with no content encryption: expected error")
+	}
+}
+
+func TestRawJWKKeyParseErrors(t *testing.T) {
+	// Ed25519: missing D and/or X.
+	if _, err := (rawJSONWebKey{}).edPrivateKey(); err == nil {
+		t.Error("edPrivateKey with missing D/X: expected error")
+	}
+	if _, err := (rawJSONWebKey{D: newBuffer([]byte("d"))}).edPrivateKey(); err == nil {
+		t.Error("edPrivateKey with missing X: expected error")
+	}
+	if _, err := (rawJSONWebKey{}).edPublicKey(); err == nil {
+		t.Error("edPublicKey with missing X: expected error")
+	}
+
+	// RSA private: missing fields.
+	if _, err := (rawJSONWebKey{}).rsaPrivateKey(); err == nil {
+		t.Error("rsaPrivateKey with missing fields: expected error")
+	}
+
+	// EC private: missing coordinates.
+	if _, err := (rawJSONWebKey{Crv: "P-256"}).ecPrivateKey(); err == nil {
+		t.Error("ecPrivateKey with missing X/Y/D: expected error")
+	}
+}
+
+func TestParseDetachedBranches(t *testing.T) {
+	// nil payload is rejected up front.
+	if _, err := ParseDetached("a.b.c", nil, []SignatureAlgorithm{HS256}); err == nil {
+		t.Error("ParseDetached with nil payload: expected error")
+	}
+
+	// Round-trip a detached signature so the success path is exercised.
+	signer, err := NewSigner(SigningKey{Algorithm: HS256, Key: covHMACKey1}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := signer.Sign([]byte("payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	detached, err := obj.DetachedCompactSerialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseDetached(detached, []byte("payload"), []SignatureAlgorithm{HS256})
+	if err != nil {
+		t.Fatalf("ParseDetached: %v", err)
+	}
+	if err := parsed.DetachedVerify([]byte("payload"), covHMACKey1); err != nil {
+		t.Errorf("DetachedVerify: %v", err)
+	}
+}

--- a/coverage_opaque_test.go
+++ b/coverage_opaque_test.go
@@ -1,0 +1,65 @@
+/*-
+ * Copyright 2024 go-jose authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"errors"
+	"testing"
+)
+
+// failingOpaqueSigner reports a single algorithm but always fails to sign.
+type failingOpaqueSigner struct{}
+
+func (failingOpaqueSigner) Public() *JSONWebKey        { return &JSONWebKey{Key: &rsaTestKey.PublicKey} }
+func (failingOpaqueSigner) Algs() []SignatureAlgorithm { return []SignatureAlgorithm{RS256} }
+func (failingOpaqueSigner) SignPayload([]byte, SignatureAlgorithm) ([]byte, error) {
+	return nil, errors.New("sign failed")
+}
+
+// failingOpaqueKeyEncrypter reports a single algorithm.
+type failingOpaqueKeyEncrypter struct{}
+
+func (failingOpaqueKeyEncrypter) KeyID() string        { return "kid" }
+func (failingOpaqueKeyEncrypter) Algs() []KeyAlgorithm { return []KeyAlgorithm{A128KW} }
+func (failingOpaqueKeyEncrypter) encryptKey([]byte, KeyAlgorithm) (recipientInfo, error) {
+	return recipientInfo{}, errors.New("encrypt failed")
+}
+
+func TestOpaqueErrorBranches(t *testing.T) {
+	// newOpaqueSigner: requested algorithm not in the signer's Algs().
+	if _, err := newOpaqueSigner(ES256, failingOpaqueSigner{}); err != ErrUnsupportedAlgorithm {
+		t.Errorf("newOpaqueSigner unsupported alg = %v", err)
+	}
+
+	// opaqueSigner.signPayload: underlying SignPayload returns an error.
+	os := &opaqueSigner{signer: failingOpaqueSigner{}}
+	if _, err := os.signPayload([]byte("x"), RS256); err == nil {
+		t.Error("opaqueSigner.signPayload: expected error")
+	}
+
+	// newOpaqueKeyEncrypter: requested algorithm not in the encrypter's Algs().
+	if _, err := newOpaqueKeyEncrypter(A256KW, failingOpaqueKeyEncrypter{}); err != ErrUnsupportedAlgorithm {
+		t.Errorf("newOpaqueKeyEncrypter unsupported alg = %v", err)
+	}
+
+	// opaqueKeyDecrypter.decryptKey: merged headers fail to sanitize (kid is a number).
+	okd := &opaqueKeyDecrypter{decrypter: makeOpaqueKeyDecrypter(t, rsaTestKey, RSA_OAEP)}
+	badHeaders := rawHeader{headerKeyID: rawMsg(`5`)}
+	if _, err := okd.decryptKey(badHeaders, &recipientInfo{}, nil); err == nil {
+		t.Error("opaqueKeyDecrypter.decryptKey with unsanitizable headers: expected error")
+	}
+}

--- a/coverage_rand_test.go
+++ b/coverage_rand_test.go
@@ -1,0 +1,55 @@
+/*-
+ * Copyright 2024 go-jose authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestBrokenRandFailures exercises the "random source failed" error branches in
+// the low-level crypto, which are otherwise unreachable with a working RNG.
+func TestBrokenRandFailures(t *testing.T) {
+	defer resetRandReader()
+	broken := func() { randReader = bytes.NewReader([]byte{}) }
+
+	// AEAD content cipher: IV generation fails.
+	broken()
+	if _, err := getContentCipher(A128GCM).encrypt(make([]byte, 16), nil, []byte("pt")); err == nil {
+		t.Error("content cipher encrypt with broken rand: expected error")
+	}
+
+	// Symmetric AES-GCM key wrap: IV generation fails.
+	broken()
+	if _, err := (&symmetricKeyCipher{key: make([]byte, 16)}).encryptKey(make([]byte, 16), A128GCMKW); err == nil {
+		t.Error("symmetric encryptKey with broken rand: expected error")
+	}
+
+	// ECDH ephemeral key generation fails (also covers ecKeyGenerator.genKey).
+	broken()
+	ev := ecEncrypterVerifier{publicKey: &ecTestKey256.PublicKey}
+	if _, err := ev.encryptKey(make([]byte, 16), ECDH_ES_A128KW); err == nil {
+		t.Error("ec encryptKey with broken rand: expected error")
+	}
+
+	// ECDSA signing fails when the RNG is broken.
+	broken()
+	es := ecDecrypterSigner{privateKey: ecTestKey256}
+	if _, err := es.signPayload([]byte("payload"), ES256); err == nil {
+		t.Error("ec signPayload with broken rand: expected error")
+	}
+}

--- a/coverage_signing_test.go
+++ b/coverage_signing_test.go
@@ -1,0 +1,163 @@
+/*-
+ * Copyright 2024 go-jose authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"testing"
+)
+
+var covHMACKey1 = []byte("0123456789abcdef0123456789abcdef")
+var covHMACKey2 = []byte("fedcba9876543210fedcba9876543210")
+
+func covSignHS256(t *testing.T, payload []byte) *JSONWebSignature {
+	t.Helper()
+	signer, err := NewSigner(SigningKey{Algorithm: HS256, Key: covHMACKey1}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return obj
+}
+
+func TestUnsafePayloadWithoutVerification(t *testing.T) {
+	obj := covSignHS256(t, []byte("payload"))
+	if got := string(obj.UnsafePayloadWithoutVerification()); got != "payload" {
+		t.Errorf("UnsafePayloadWithoutVerification = %q, want payload", got)
+	}
+}
+
+func TestDetachedVerifyErrorBranches(t *testing.T) {
+	obj := covSignHS256(t, []byte("payload"))
+
+	// Unsupported verification key type -> newVerifier default branch
+	if err := obj.DetachedVerify([]byte("payload"), "not-a-key"); err == nil {
+		t.Error("DetachedVerify with bad key type: expected error")
+	}
+
+	// Wrong key -> ErrCryptoFailure
+	if err := obj.DetachedVerify([]byte("payload"), covHMACKey2); err == nil {
+		t.Error("DetachedVerify with wrong key: expected error")
+	}
+
+	// crit in the (integrity-unprotected) per-signature header -> checkNoCritical
+	critUnprotected := `{"payload":"cGF5bG9hZA",` +
+		`"protected":"eyJhbGciOiJIUzI1NiJ9","header":{"crit":["x"]},"signature":"AAAA"}`
+	obj2, err := ParseSigned(critUnprotected, []SignatureAlgorithm{HS256})
+	if err != nil {
+		t.Fatalf("parse crit-unprotected: %v", err)
+	}
+	if err := obj2.DetachedVerify([]byte("payload"), covHMACKey1); err == nil {
+		t.Error("DetachedVerify with crit in unprotected header: expected error")
+	}
+
+	// Unsupported crit in the protected header -> checkSupportedCritical
+	critProtected := `{"payload":"cGF5bG9hZA",` +
+		`"protected":"eyJhbGciOiJIUzI1NiIsImNyaXQiOlsieCJdfQ","signature":"AAAA"}`
+	obj3, err := ParseSigned(critProtected, []SignatureAlgorithm{HS256})
+	if err != nil {
+		t.Fatalf("parse crit-protected: %v", err)
+	}
+	if err := obj3.DetachedVerify([]byte("payload"), covHMACKey1); err == nil {
+		t.Error("DetachedVerify with unsupported protected crit: expected error")
+	}
+
+	// More than one signature -> "too many signatures"
+	multi := `{"payload":"cGF5bG9hZA","signatures":[` +
+		`{"protected":"eyJhbGciOiJIUzI1NiJ9","signature":"AAAA"},` +
+		`{"protected":"eyJhbGciOiJIUzI1NiJ9","signature":"BBBB"}]}`
+	objMulti, err := ParseSigned(multi, []SignatureAlgorithm{HS256})
+	if err != nil {
+		t.Fatalf("parse multi: %v", err)
+	}
+	if err := objMulti.DetachedVerify([]byte("payload"), covHMACKey1); err == nil {
+		t.Error("DetachedVerify with multiple signatures: expected error")
+	}
+}
+
+func TestVerifyMultiBranches(t *testing.T) {
+	// Two real signatures under different keys.
+	signer, err := NewMultiSigner([]SigningKey{
+		{Algorithm: HS256, Key: covHMACKey1},
+		{Algorithm: HS256, Key: covHMACKey2},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := signer.Sign([]byte("payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify with the second key: the loop skips signature 0 (verify fails ->
+	// continue) and succeeds on signature 1, exercising the continue + success.
+	idx, _, payload, err := obj.VerifyMulti(covHMACKey2)
+	if err != nil {
+		t.Fatalf("VerifyMulti: %v", err)
+	}
+	if idx != 1 {
+		t.Errorf("VerifyMulti index = %d, want 1", idx)
+	}
+	if string(payload) != "payload" {
+		t.Errorf("VerifyMulti payload = %q", payload)
+	}
+
+	// Unsupported key type -> newVerifier error path in DetachedVerifyMulti
+	if _, _, _, err := obj.VerifyMulti("not-a-key"); err == nil {
+		t.Error("VerifyMulti with bad key type: expected error")
+	}
+
+	// A wrong key for every signature -> all continue, then error.
+	if _, _, _, err := obj.VerifyMulti([]byte("totally-wrong-key-of-right-length__")); err == nil {
+		t.Error("VerifyMulti with wrong key: expected error")
+	}
+}
+
+func TestSignWithNonceAndBadB64(t *testing.T) {
+	// NonceSource branch in Sign.
+	signer, err := NewSigner(
+		SigningKey{Algorithm: HS256, Key: covHMACKey1},
+		&SignerOptions{NonceSource: staticNonceSource("nonce-1")},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := signer.Sign([]byte("payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseSigned(obj.FullSerialize(), []SignatureAlgorithm{HS256})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Signatures[0].Protected.Nonce != "nonce-1" {
+		t.Errorf("nonce = %q, want nonce-1", parsed.Signatures[0].Protected.Nonce)
+	}
+
+	// A non-bool "b64" protected header -> "Invalid b64 header parameter".
+	badB64 := &SignerOptions{}
+	badB64.WithHeader("b64", "not-a-bool")
+	signer2, err := NewSigner(SigningKey{Algorithm: HS256, Key: covHMACKey1}, badB64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := signer2.Sign([]byte("payload")); err == nil {
+		t.Error("Sign with non-bool b64 header: expected error")
+	}
+}

--- a/coverage_symmetric_test.go
+++ b/coverage_symmetric_test.go
@@ -1,0 +1,95 @@
+/*-
+ * Copyright 2024 go-jose authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"testing"
+)
+
+func TestSymmetricDecryptKeyErrorBranches(t *testing.T) {
+	c16 := &symmetricKeyCipher{key: make([]byte, 16)}
+	cBad := &symmetricKeyCipher{key: make([]byte, 5)} // invalid AES key size
+	ek := []byte("0123456789abcdef")                  // 16 bytes of junk
+
+	hdr := func(pairs ...string) rawHeader {
+		h := rawHeader{}
+		for i := 0; i+1 < len(pairs); i += 2 {
+			h[HeaderKey(pairs[i])] = rawMsg(pairs[i+1])
+		}
+		return h
+	}
+
+	cases := []struct {
+		name      string
+		cipher    *symmetricKeyCipher
+		headers   rawHeader
+		recipient *recipientInfo
+	}{
+		{"nil recipient", c16, hdr("alg", `"A128KW"`), nil},
+		{"missing encrypted key", c16, hdr("alg", `"A128KW"`), &recipientInfo{}},
+		{"gcmkw bad iv", c16, hdr("alg", `"A128GCMKW"`, "iv", `5`), &recipientInfo{encryptedKey: ek}},
+		{"gcmkw bad tag", c16, hdr("alg", `"A128GCMKW"`, "iv", `"AAAA"`, "tag", `5`), &recipientInfo{encryptedKey: ek}},
+		{"gcmkw decrypt fail", c16, hdr("alg", `"A128GCMKW"`, "iv", `"AAAAAAAAAAAAAAAA"`, "tag", `"AAAAAAAAAAAAAAAAAAAAAA"`), &recipientInfo{encryptedKey: ek}},
+		{"kw bad key size", cBad, hdr("alg", `"A128KW"`), &recipientInfo{encryptedKey: ek}},
+		{"kw unwrap fail", c16, hdr("alg", `"A128KW"`), &recipientInfo{encryptedKey: ek}},
+		{"pbes2 missing p2s", c16, hdr("alg", `"PBES2-HS256+A128KW"`), &recipientInfo{encryptedKey: ek}},
+		{"pbes2 bad p2s", c16, hdr("alg", `"PBES2-HS256+A128KW"`, "p2s", `5`), &recipientInfo{encryptedKey: ek}},
+		{"pbes2 bad p2c", c16, hdr("alg", `"PBES2-HS256+A128KW"`, "p2s", `"AAAA"`, "p2c", `"x"`), &recipientInfo{encryptedKey: ek}},
+		{"pbes2 p2c zero", c16, hdr("alg", `"PBES2-HS256+A128KW"`, "p2s", `"AAAA"`, "p2c", `0`), &recipientInfo{encryptedKey: ek}},
+		{"pbes2 p2c too high", c16, hdr("alg", `"PBES2-HS256+A128KW"`, "p2s", `"AAAA"`, "p2c", `2000000`), &recipientInfo{encryptedKey: ek}},
+		{"pbes2 unwrap fail", c16, hdr("alg", `"PBES2-HS256+A128KW"`, "p2s", `"AAAA"`, "p2c", `1000`), &recipientInfo{encryptedKey: ek}},
+		{"unsupported alg", c16, hdr("alg", `"BOGUS"`), &recipientInfo{encryptedKey: ek}},
+	}
+	for _, c := range cases {
+		if _, err := c.cipher.decryptKey(c.headers, c.recipient, nil); err == nil {
+			t.Errorf("decryptKey(%s): expected error", c.name)
+		}
+	}
+
+	// DIRECT returns a clone of the key with no error.
+	got, err := c16.decryptKey(hdr("alg", `"dir"`), &recipientInfo{}, nil)
+	if err != nil || len(got) != 16 {
+		t.Errorf("decryptKey(dir) = (%v,%v)", got, err)
+	}
+}
+
+func TestContentCipherBadKey(t *testing.T) {
+	// getAead fails for an invalid key length, in both encrypt and decrypt.
+	for _, enc := range []ContentEncryption{A128GCM, A128CBC_HS256} {
+		cipher := getContentCipher(enc)
+		if cipher == nil {
+			t.Fatalf("no cipher for %s", enc)
+		}
+		if _, err := cipher.encrypt(make([]byte, 3), nil, []byte("pt")); err == nil {
+			t.Errorf("%s encrypt with bad key: expected error", enc)
+		}
+		parts := &aeadParts{iv: make([]byte, 12), ciphertext: []byte("x"), tag: make([]byte, 16)}
+		if _, err := cipher.decrypt(make([]byte, 3), nil, parts); err == nil {
+			t.Errorf("%s decrypt with bad key: expected error", enc)
+		}
+	}
+}
+
+func TestSymmetricEncryptKeyErrorBranches(t *testing.T) {
+	cBad := &symmetricKeyCipher{key: make([]byte, 5)} // invalid AES key size
+	cek := make([]byte, 16)
+
+	// A128KW with an invalid key size -> aes.NewCipher error.
+	if _, err := cBad.encryptKey(cek, A128KW); err == nil {
+		t.Error("encryptKey A128KW with bad key size: expected error")
+	}
+}

--- a/jwt/coverage_builder_test.go
+++ b/jwt/coverage_builder_test.go
@@ -1,0 +1,93 @@
+/*-
+ * Copyright 2024 go-jose authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import (
+	"testing"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+func TestBuilderTokenMethods(t *testing.T) {
+	// signedBuilder.Token()
+	signedTok, err := Signed(rsaSigner).Claims(sampleClaims).Token()
+	if err != nil {
+		t.Fatalf("signed Token(): %v", err)
+	}
+	var got Claims
+	if err := signedTok.Claims(&testPrivRSAKey1.PublicKey, &got); err != nil {
+		t.Fatalf("signed claims: %v", err)
+	}
+	if got.Issuer != sampleClaims.Issuer {
+		t.Errorf("issuer = %q, want %q", got.Issuer, sampleClaims.Issuer)
+	}
+
+	// encryptedBuilder.Token()
+	encrypter, err := jose.NewEncrypter(
+		jose.A128GCM,
+		jose.Recipient{Algorithm: jose.A128KW, Key: sharedEncryptionKey},
+		(&jose.EncrypterOptions{}).WithContentType("JWT"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encTok, err := Encrypted(encrypter).Claims(sampleClaims).Token()
+	if err != nil {
+		t.Fatalf("encrypted Token(): %v", err)
+	}
+	got = Claims{}
+	if err := encTok.Claims(sharedEncryptionKey, &got); err != nil {
+		t.Fatalf("encrypted claims: %v", err)
+	}
+	if got.Issuer != sampleClaims.Issuer {
+		t.Errorf("encrypted issuer = %q, want %q", got.Issuer, sampleClaims.Issuer)
+	}
+}
+
+func TestNestedBuilderTokenAndFullSerialize(t *testing.T) {
+	encrypter, err := jose.NewEncrypter(
+		jose.A128CBC_HS256,
+		jose.Recipient{Algorithm: jose.A128KW, Key: sharedEncryptionKey},
+		(&jose.EncrypterOptions{}).WithContentType("JWT").WithType("JWT"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// nestedBuilder.Token() builds a NestedJSONWebToken. (Its allowed signature
+	// algorithms are not set on this path, so decrypt it via a fresh parse below.)
+	nested, err := SignedAndEncrypted(rsaSigner, encrypter).Claims(sampleClaims).Token()
+	if err != nil {
+		t.Fatalf("nested Token(): %v", err)
+	}
+	if len(nested.Headers) == 0 {
+		t.Error("nested Token() produced no headers")
+	}
+
+	// nestedBuilder.FullSerialize() is a public method that is not part of the
+	// NestedBuilder interface, so it is only reachable via the concrete type.
+	nb := SignedAndEncrypted(rsaSigner, encrypter).Claims(sampleClaims).(*nestedBuilder)
+	full, err := nb.FullSerialize()
+	if err != nil {
+		t.Fatalf("nested FullSerialize(): %v", err)
+	}
+	// FullSerialize emits JWE JSON serialization (not compact), so just confirm
+	// it produced a non-empty JSON object.
+	if len(full) == 0 || full[0] != '{' {
+		t.Errorf("nested FullSerialize() = %q, want a JSON object", full)
+	}
+}

--- a/opaque_test.go
+++ b/opaque_test.go
@@ -17,6 +17,7 @@
 package jose
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 )
@@ -266,6 +267,50 @@ func TestOpaqueSignerKeyRotation(t *testing.T) {
 			jws2 = rtSerialize(t, serializer, jws2, vw, alg)
 			if kid := jws2.Signatures[0].Protected.KeyID; kid != "next" {
 				t.Errorf("expected kid %q but got %q", "next", kid)
+			}
+		}
+	}
+}
+
+func TestRoundtripsJWEOpaque(t *testing.T) {
+	// Exercises the opaque key-encrypter and key-decrypter paths
+	// (newOpaqueKeyEncrypter, opaqueKeyEncrypter.encryptKey,
+	// opaqueKeyDecrypter.decryptKey) using the wrappers above, which were
+	// previously defined but unused.
+	keyAlgs := []KeyAlgorithm{RSA1_5, RSA_OAEP, RSA_OAEP_256}
+	encs := []ContentEncryption{A128GCM, A256GCM, A128CBC_HS256, A256CBC_HS512}
+
+	serializers := []func(*JSONWebEncryption) (string, error){
+		func(obj *JSONWebEncryption) (string, error) { return obj.CompactSerialize() },
+		func(obj *JSONWebEncryption) (string, error) { return obj.FullSerialize(), nil },
+	}
+
+	for _, alg := range keyAlgs {
+		for _, enc := range encs {
+			for i, serializer := range serializers {
+				ke := makeOpaqueKeyEncrypter(t, &rsaTestKey.PublicKey, alg, "test-kid")
+				kd := makeOpaqueKeyDecrypter(t, rsaTestKey, alg)
+
+				encrypter, err := NewEncrypter(enc, Recipient{Algorithm: alg, Key: ke}, nil)
+				if err != nil {
+					t.Fatal(err, alg, enc, i)
+				}
+
+				plaintext := []byte("foo bar baz")
+				jwe, err := encrypter.Encrypt(plaintext)
+				if err != nil {
+					t.Fatal(err, alg, enc, i)
+				}
+
+				jwe = jweSerialize(t, serializer, jwe, kd, alg, enc)
+
+				decrypted, err := jwe.Decrypt(kd)
+				if err != nil {
+					t.Fatal(err, alg, enc, i)
+				}
+				if !bytes.Equal(decrypted, plaintext) {
+					t.Errorf("alg %s enc %s serializer %d: got %q, want %q", alg, enc, i, decrypted, plaintext)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I have asked Claude to check our code coverage and increase coverage where feasible.

It describes the change as follows:

Adds focused unit tests targeting previously-uncovered error branches across the library, raising statement coverage:

  - main package: 89.4% -> 95.8%
  - jwt package:  85.6% -> 92.1%

Highlights:
  - header getters / sanitize / merge error branches (shared.go)
  - symmetric & asymmetric key-cipher error paths, exercised directly
  - decrypt/encrypt error branches via crafted JWEs (crypter.go)
  - RNG-failure branches via a swapped randReader
  - JWK thumbprints, Valid, Public, and Unmarshal/Marshal errors
  - the JWS Verify family and JWE/JWS parse error branches
  - the opaque JWE round-trip (scaffolding existed but was unused)
  - jwt builder Token()/FullSerialize() methods

The remaining uncovered branches are unreachable defensive code (documented "impossible" checks), dead code, and deterministic-crypto error returns that cannot fail.