### PR TITLE
jws: skip signature on ErrJWKSKidNotFound

### DIFF
--- a/signing.go
+++ b/signing.go
@@ -499,17 +499,14 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 		}
 
 		// If the verification key is a JWK Set, pick a key based on this signature's
-		// "kid" header. On error, return immediately so we can provide ErrJWSKidNotFound
-		// instead of the more generic ErrCryptoFailure. This means we error on
-		// the first ErrJWSKidNotFound, even if a subsequent signature might succeed,
-		// which is not ideal but requires a little refactoring to fix.
+		// "kid" header. If no match, skip this signature.
 		key, err := tryJWKS(verificationKey, signature.Header)
 		if err != nil {
-			return -1, Signature{}, err
+			continue
 		}
 		verifier, err := newVerifier(key)
 		if err != nil {
-			return -1, Signature{}, err
+			continue
 		}
 
 		input, err := obj.computeAuthData(payload, &signature)

--- a/signing_test.go
+++ b/signing_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -386,10 +385,16 @@ func TestVerifyMultiJWKSNoMatchingKid(t *testing.T) {
 
 	_, _, _, err = parsed.VerifyMulti(jwks)
 	if err == nil {
-		t.Fatal("expected error when no signature kid is present in the JWKS")
+		t.Error("expected error when no signature kid is present in the JWKS")
 	}
-	if !errors.Is(err, ErrJWKSKidNotFound) {
-		t.Errorf("got error %v, want ErrJWKSKidNotFound", err)
+
+	// The JWKS contains a usable key matching the second signature.
+	jwks = &JSONWebKeySet{Keys: []JSONWebKey{
+		{KeyID: "bar", Key: key.Public()},
+	}}
+	_, _, _, err = parsed.VerifyMulti(jwks)
+	if err != nil {
+		t.Errorf("verifying with JWK Set that includes 'bar': %s", err)
 	}
 }
 


### PR DESCRIPTION
The replaces the early return in `VerifyMulti()`/`DetachedVerifyMulti`. The single-signature variants (including JWT validation) still returns ErrJWKSKidNotFound.

This means a multi-signature JWS validated against a JWK Set won't return ErrJWKSKidNotFound, but will fall through to ErrCryptoFailure if none of the signatures match.

The change here is based on looking back at #128 and noticing that the justification was oriented around JWTs, which have a single signature. That, and verification of a single-signature JWS, is the most useful place to return the specific ErrJWKSKidNotFound. For multi-signature cases it makes sense to fall through.

Fixes #246.