### PR TITLE
Filter unauthenticated JWE identity headers

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -461,7 +461,7 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 		return nil, err
 	}
 
-	key, err := tryJWKS(decryptionKey, obj.Header)
+	key, err := tryJWKS(decryptionKey, Header{KeyID: headers.getString(headerKeyID)})
 	if err != nil {
 		return nil, err
 	}
@@ -515,8 +515,8 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 
 // DecryptMulti decrypts and validates the object and returns the plaintexts,
 // with support for multiple recipients. It returns the index of the recipient
-// for which the decryption was successful, the merged headers for that recipient,
-// and the plaintext.
+// for which the decryption was successful, the caller-visible headers for that
+// recipient, and the plaintext.
 //
 // The decryptionKey argument must have one of the types allowed for the
 // decryptionKey argument of Decrypt().
@@ -531,7 +531,7 @@ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Heade
 		return -1, Header{}, nil, err
 	}
 
-	key, err := tryJWKS(decryptionKey, obj.Header)
+	key, err := tryJWKS(decryptionKey, Header{KeyID: globalHeaders.getString(headerKeyID)})
 	if err != nil {
 		return -1, Header{}, nil, err
 	}
@@ -583,7 +583,7 @@ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Heade
 		}
 
 		index = i
-		headers = recipientHeaders
+		headers = obj.publicHeaders(&obj.recipients[i])
 		break
 	}
 

--- a/crypter_test.go
+++ b/crypter_test.go
@@ -23,7 +23,10 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/big"
@@ -329,6 +332,142 @@ func TestEncrypterWithJWKAndKeyIDByValue(t *testing.T) {
 	if parsed2.Header.KeyID != "test-id-value" {
 		t.Errorf("expected message to have key id from JWK by value, but found '%s' instead", parsed2.Header.KeyID)
 	}
+}
+
+func TestJWEUnprotectedIdentityHeadersAreNotExposed(t *testing.T) {
+	encrypter, err := NewEncrypter(A128GCM, Recipient{
+		Algorithm: RSA_OAEP,
+		Key:       &rsaTestKey.PublicKey,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ciphertext, err := encrypter.Encrypt([]byte("Lorem ipsum dolor sit amet"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := map[string]interface{}{
+		"kid":    "attacker",
+		"jwk":    JSONWebKey{Key: &ecTestKey256.PublicKey, KeyID: "attacker"},
+		"x5c":    []string{base64.StdEncoding.EncodeToString(testCertificates[0].Raw)},
+		"custom": "preserved",
+	}
+	serialized := injectJWEHeader(t, ciphertext.FullSerialize(), "unprotected", header)
+
+	parsed, err := ParseEncrypted(serialized, []KeyAlgorithm{RSA_OAEP}, []ContentEncryption{A128GCM})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plaintext, err := parsed.Decrypt(rsaTestKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(plaintext) != "Lorem ipsum dolor sit amet" {
+		t.Fatalf("plaintext = %q", plaintext)
+	}
+
+	keySet := JSONWebKeySet{
+		Keys: []JSONWebKey{{Key: rsaTestKey, KeyID: "attacker"}},
+	}
+	plaintext, err = parsed.Decrypt(keySet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(plaintext) != "Lorem ipsum dolor sit amet" {
+		t.Fatalf("JWKS plaintext = %q", plaintext)
+	}
+
+	if parsed.Header.KeyID != "" {
+		t.Fatalf("unprotected kid was exposed as %q", parsed.Header.KeyID)
+	}
+	if parsed.Header.JSONWebKey != nil {
+		t.Fatal("unprotected JWK was exposed")
+	}
+	_, err = parsed.Header.Certificates(x509.VerifyOptions{})
+	if err != ErrMissingX5cHeader {
+		t.Fatalf("unprotected x5c error = %v, want %v", err, ErrMissingX5cHeader)
+	}
+	if parsed.Header.ExtraHeaders[HeaderKey("custom")] != "preserved" {
+		t.Fatalf("custom header = %v", parsed.Header.ExtraHeaders[HeaderKey("custom")])
+	}
+}
+
+func TestJWERecipientUnprotectedIdentityHeadersAreNotExposed(t *testing.T) {
+	encrypter, err := NewEncrypter(A128GCM, Recipient{
+		Algorithm: RSA_OAEP,
+		Key:       &rsaTestKey.PublicKey,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ciphertext, err := encrypter.Encrypt([]byte("Lorem ipsum dolor sit amet"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := map[string]interface{}{
+		"kid":    "attacker",
+		"jwk":    JSONWebKey{Key: &ecTestKey256.PublicKey, KeyID: "attacker"},
+		"x5c":    []string{base64.StdEncoding.EncodeToString(testCertificates[0].Raw)},
+		"custom": "preserved",
+	}
+	serialized := injectJWEHeader(t, ciphertext.FullSerialize(), "header", header)
+
+	parsed, err := ParseEncrypted(serialized, []KeyAlgorithm{RSA_OAEP}, []ContentEncryption{A128GCM})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	index, headerOut, plaintext, err := parsed.DecryptMulti(rsaTestKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if index != 0 {
+		t.Fatalf("recipient index = %d, want 0", index)
+	}
+	if string(plaintext) != "Lorem ipsum dolor sit amet" {
+		t.Fatalf("plaintext = %q", plaintext)
+	}
+	if headerOut.KeyID != "" {
+		t.Fatalf("unprotected kid was exposed as %q", headerOut.KeyID)
+	}
+	if headerOut.JSONWebKey != nil {
+		t.Fatal("unprotected JWK was exposed")
+	}
+	_, err = headerOut.Certificates(x509.VerifyOptions{})
+	if err != ErrMissingX5cHeader {
+		t.Fatalf("unprotected x5c error = %v, want %v", err, ErrMissingX5cHeader)
+	}
+	if headerOut.ExtraHeaders[HeaderKey("custom")] != "preserved" {
+		t.Fatalf("custom header = %v", headerOut.ExtraHeaders[HeaderKey("custom")])
+	}
+}
+
+func injectJWEHeader(
+	t *testing.T,
+	serialized string,
+	field string,
+	header map[string]interface{},
+) string {
+	t.Helper()
+
+	var raw map[string]interface{}
+	err := json.Unmarshal([]byte(serialized), &raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw[field] = header
+
+	out, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
 }
 
 func TestEncrypterWithBrokenRand(t *testing.T) {

--- a/jwe.go
+++ b/jwe.go
@@ -83,6 +83,42 @@ func (obj JSONWebEncryption) mergedHeaders(recipient *recipientInfo) rawHeader {
 	return out
 }
 
+// publicHeaders returns caller-visible header values without unprotected JWE identity.
+func (obj JSONWebEncryption) publicHeaders(recipient *recipientInfo) rawHeader {
+	out := rawHeader{}
+	out.merge(obj.protected)
+	mergePublicJWEHeaders(out, obj.unprotected)
+
+	if recipient != nil {
+		mergePublicJWEHeaders(out, recipient.header)
+	}
+
+	return out
+}
+
+func mergePublicJWEHeaders(dst rawHeader, src *rawHeader) {
+	if src == nil {
+		return
+	}
+
+	for k, v := range *src {
+		if isJWEIdentityHeader(k) || dst.isSet(k) {
+			continue
+		}
+
+		dst[k] = v
+	}
+}
+
+func isJWEIdentityHeader(k HeaderKey) bool {
+	switch k {
+	case headerKeyID, headerJWK, headerX5c:
+		return true
+	default:
+		return false
+	}
+}
+
 // Get the additional authenticated data from a JWE object.
 func (obj JSONWebEncryption) computeAuthData() []byte {
 	var protected string
@@ -205,10 +241,10 @@ func (parsed *rawJSONWebEncryption) sanitized(
 	// Note: this must be called _after_ we parse the protected header,
 	// otherwise fields from the protected header will not get picked up.
 	var err error
-	mergedHeaders := obj.mergedHeaders(nil)
-	obj.Header, err = mergedHeaders.sanitized()
+	publicHeaders := obj.publicHeaders(nil)
+	obj.Header, err = publicHeaders.sanitized()
 	if err != nil {
-		return nil, fmt.Errorf("go-jose/go-jose: cannot sanitize merged headers: %v (%v)", err, mergedHeaders)
+		return nil, fmt.Errorf("go-jose/go-jose: cannot sanitize headers: %v (%v)", err, publicHeaders)
 	}
 
 	if len(parsed.Recipients) == 0 {


### PR DESCRIPTION
## Summary

Fixes #253.

This patch prevents unauthenticated JWE identity headers from being exposed through
`JSONWebEncryption.Header` and the `Header` returned by `DecryptMulti`.
[RFC 7516 Section 2](https://www.rfc-editor.org/rfc/rfc7516.html#section-2) defines
the JWE Protected Header as integrity protected by the authenticated encryption
operation, and the JWE Shared Unprotected Header and JWE Per-Recipient Unprotected
Header as not integrity protected. The caller-visible header merge now preserves
protected values and non-identity unprotected metadata, but omits unprotected `kid`,
`jwk`, and `x5c`.

The raw merged JOSE Header values are still used for cryptographic processing,
recipient handling, and JWKS key selection. In particular, an unprotected `kid` can
still serve as a pre-auth JWKS key-selection hint; it is just not exposed after
decryption as trusted identity metadata.

## Verification

- Base: `go-jose/go-jose` `main` at `6f55db3e774c68bc78bee49c5e5e59186d1d55a1`
- fail-first regression: the new focused tests fail on current `main` because
  unprotected `kid` is exposed from both shared and recipient headers
- root-cause test: `go test . -run '^TestJWE(UnprotectedIdentityHeadersAreNotExposed|RecipientUnprotectedIdentityHeadersAreNotExposed)$' -count=1 -v`: passes
- adjacent JWE/JWK controls: `go test . -run '^(TestEncrypterWithJWKAndKeyIDByReference|TestEncrypterWithJWKAndKeyIDByValue|TestJWEUnprotectedIdentityHeadersAreNotExposed|TestJWERecipientUnprotectedIdentityHeadersAreNotExposed|TestRejectUnprotectedJWENonce|TestCompactParseJWE|TestFullParseJWE|TestJWENilProtected|TestMultiRecipientJWE)$' -count=1 -v`: passes
- repo checks: `go build -v ./...`: passes; `go test ./...`: passes
- formatting/static checks: `gofmt -l jwe.go crypter.go crypter_test.go`: no output; `git diff --check upstream/main..HEAD`: passes; `go build .` in `jose-util`: passes
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`: no vulnerabilities found
