### PR TITLE
Verify OpaqueSigner's Public() return is public

### DIFF
--- a/opaque.go
+++ b/opaque.go
@@ -46,6 +46,11 @@ func newOpaqueSigner(alg SignatureAlgorithm, signer OpaqueSigner) (recipientSigI
 		return recipientSigInfo{}, ErrUnsupportedAlgorithm
 	}
 
+	pk := signer.Public()
+	if pk != nil && !pk.IsPublic() {
+		return recipientSigInfo{}, ErrNotPublic
+	}
+
 	return recipientSigInfo{
 		sigAlg:    alg,
 		publicKey: signer.Public,

--- a/opaque_test.go
+++ b/opaque_test.go
@@ -180,7 +180,7 @@ func makeOpaqueSigner(t *testing.T, signingKey interface{}, alg SignatureAlgorit
 	return &signWrapper{
 		wrapped: ri.signer,
 		algs:    []SignatureAlgorithm{alg},
-		pk:      &JSONWebKey{Key: ri.publicKey()},
+		pk:      ri.publicKey(),
 	}
 }
 

--- a/opaque_test.go
+++ b/opaque_test.go
@@ -18,6 +18,10 @@ package jose
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -346,4 +350,33 @@ func jweSerialize(t *testing.T,
 		t.Fatal(err)
 	}
 	return jwe
+}
+
+type badSigner struct {
+	*ecdsa.PrivateKey
+}
+
+func (bs badSigner) Algs() []SignatureAlgorithm {
+	return []SignatureAlgorithm{ES256}
+}
+
+func (bs badSigner) SignPayload([]byte, SignatureAlgorithm) ([]byte, error) {
+	panic("Shouldn't be called in this test")
+}
+
+func (bs badSigner) Public() *JSONWebKey {
+	return &JSONWebKey{
+		Key:   bs.PrivateKey,
+		KeyID: "BS",
+	}
+}
+
+// TestOpaqueSignerNonPublic ensures a private key returned in Public() doesn't end up in an embedded JWK
+func TestOpaqueSignerNonPublic(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	var os OpaqueSigner = badSigner{key}
+	_, err := NewSigner(SigningKey{Algorithm: ES256, Key: os}, &SignerOptions{EmbedJWK: true})
+	if !errors.Is(err, ErrNotPublic) {
+		t.Fatal("Expected ErrNotPublic when using BadSigner")
+	}
 }

--- a/opaque_test.go
+++ b/opaque_test.go
@@ -17,6 +17,7 @@
 package jose
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 )
@@ -194,6 +195,46 @@ func makeOpaqueVerifier(t *testing.T, verificationKey []interface{}, alg Signatu
 		verifiers = append(verifiers, verifier)
 	}
 	return &verifyWrapper{wrapped: verifiers}
+}
+
+func TestRoundtripsJWEOpaque(t *testing.T) {
+	keyAlgs := []KeyAlgorithm{RSA1_5, RSA_OAEP, RSA_OAEP_256}
+	encs := []ContentEncryption{A128GCM, A256GCM, A128CBC_HS256, A256CBC_HS512}
+
+	serializers := []func(*JSONWebEncryption) (string, error){
+		func(obj *JSONWebEncryption) (string, error) { return obj.CompactSerialize() },
+		func(obj *JSONWebEncryption) (string, error) { return obj.FullSerialize(), nil },
+	}
+
+	for _, alg := range keyAlgs {
+		for _, enc := range encs {
+			for i, serializer := range serializers {
+				ke := makeOpaqueKeyEncrypter(t, &rsaTestKey.PublicKey, alg, "test-kid")
+				kd := makeOpaqueKeyDecrypter(t, rsaTestKey, alg)
+
+				encrypter, err := NewEncrypter(enc, Recipient{Algorithm: alg, Key: ke}, nil)
+				if err != nil {
+					t.Fatal(err, alg, enc, i)
+				}
+
+				plaintext := []byte("foo bar baz")
+				jwe, err := encrypter.Encrypt(plaintext)
+				if err != nil {
+					t.Fatal(err, alg, enc, i)
+				}
+
+				jwe = jweSerialize(t, serializer, jwe, kd, alg, enc)
+
+				decrypted, err := jwe.Decrypt(kd)
+				if err != nil {
+					t.Fatal(err, alg, enc, i)
+				}
+				if !bytes.Equal(decrypted, plaintext) {
+					t.Errorf("alg %s enc %s serializer %d: got %q, want %q", alg, enc, i, decrypted, plaintext)
+				}
+			}
+		}
+	}
 }
 
 func makeOpaqueKeyEncrypter(t *testing.T, signingKey interface{}, alg KeyAlgorithm, kid string) *keyEncryptWrapper {

--- a/shared.go
+++ b/shared.go
@@ -83,6 +83,8 @@ var (
 
 	// errEmptyInput is returned when go-jose was asked to parse an empty string.
 	errEmptyInput = errors.New("go-jose/go-jose: empty input")
+
+	ErrNotPublic = errors.New("go-jose/go-jose: public key was unexpectedly not public")
 )
 
 // Key management algorithms

--- a/shared.go
+++ b/shared.go
@@ -84,6 +84,7 @@ var (
 	// errEmptyInput is returned when go-jose was asked to parse an empty string.
 	errEmptyInput = errors.New("go-jose/go-jose: empty input")
 
+	// ErrNotPublic indicates a private key was passed where a public key was expected
 	ErrNotPublic = errors.New("go-jose/go-jose: public key was unexpectedly not public")
 )
 

--- a/signing.go
+++ b/signing.go
@@ -253,7 +253,7 @@ func newJWKSigner(alg SignatureAlgorithm, signingKey JSONWebKey) (recipientSigIn
 	if recipientPubKey := recipient.getPublicKey(); recipientPubKey != nil {
 		// This should be impossible, but let's check anyway.
 		if !recipientPubKey.IsPublic() {
-			return recipientSigInfo{}, errors.New("go-jose/go-jose: public key was unexpectedly not public")
+			return recipientSigInfo{}, ErrNotPublic
 		}
 
 		// recipient.publicKey is a JWK synthesized for embedding when recipientSigInfo


### PR DESCRIPTION
If an implementation of an OpaqueSigner returned a private key in Public(), it could leak. We should prevent that from being possible.

The test helper makeOpaqueSigner function had an an extra JSONWebKey wrapper, which isn't needed. Remove it.

This reuses the same error from signing.go and exports it.

This would all be better handled in the type system, so flagging this as a spot for potential further improvements in a major revision.

Fixes #256
