### PR TITLE
Remove use of deprecated IsOnCurve and ScalarMult

### DIFF
--- a/asymmetric.go
+++ b/asymmetric.go
@@ -144,8 +144,9 @@ func newECDHRecipient(keyAlg KeyAlgorithm, publicKey *ecdsa.PublicKey) (recipien
 	if publicKey == nil {
 		return recipientKeyInfo{}, errors.New("invalid public key")
 	}
-	if _, err := publicKey.ECDH(); err != nil {
-		return recipientKeyInfo{}, errors.New("invalid public key")
+	_, err := publicKey.ECDH()
+	if err != nil {
+		return recipientKeyInfo{}, fmt.Errorf("invalid public key: %w", err)
 	}
 
 	return recipientKeyInfo{

--- a/asymmetric.go
+++ b/asymmetric.go
@@ -141,7 +141,10 @@ func newECDHRecipient(keyAlg KeyAlgorithm, publicKey *ecdsa.PublicKey) (recipien
 		return recipientKeyInfo{}, ErrUnsupportedAlgorithm
 	}
 
-	if publicKey == nil || !publicKey.Curve.IsOnCurve(publicKey.X, publicKey.Y) {
+	if publicKey == nil {
+		return recipientKeyInfo{}, errors.New("invalid public key")
+	}
+	if _, err := publicKey.ECDH(); err != nil {
 		return recipientKeyInfo{}, errors.New("invalid public key")
 	}
 
@@ -430,7 +433,10 @@ func (ctx ecDecrypterSigner) decryptKey(headers rawHeader, recipient *recipientI
 		return nil, errors.New("go-jose/go-jose: invalid epk header")
 	}
 
-	if !ctx.privateKey.Curve.IsOnCurve(publicKey.X, publicKey.Y) {
+	if publicKey.Curve != ctx.privateKey.Curve {
+		return nil, errors.New("go-jose/go-jose: invalid public key in epk header")
+	}
+	if _, err := publicKey.ECDH(); err != nil {
 		return nil, errors.New("go-jose/go-jose: invalid public key in epk header")
 	}
 

--- a/cipher/ecdh_es.go
+++ b/cipher/ecdh_es.go
@@ -17,10 +17,8 @@
 package josecipher
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"encoding/binary"
 )
 
@@ -42,20 +40,17 @@ func DeriveECDHES(alg string, apuData, apvData []byte, priv *ecdsa.PrivateKey, p
 	supPubInfo := make([]byte, 4)
 	binary.BigEndian.PutUint32(supPubInfo, uint32(size)*8)
 
-	if !priv.PublicKey.Curve.IsOnCurve(pub.X, pub.Y) {
-		panic("public key not on same curve as private key")
+	ecdhPub, err := pub.ECDH()
+	if err != nil {
+		panic("invalid public key")
 	}
-
-	z, _ := priv.Curve.ScalarMult(pub.X, pub.Y, priv.D.Bytes())
-	zBytes := z.Bytes()
-
-	// Note that calling z.Bytes() on a big.Int may strip leading zero bytes from
-	// the returned byte array. This can lead to a problem where zBytes will be
-	// shorter than expected which breaks the key derivation. Therefore we must pad
-	// to the full length of the expected coordinate here before calling the KDF.
-	octSize := dSize(priv.Curve)
-	if len(zBytes) != octSize {
-		zBytes = append(bytes.Repeat([]byte{0}, octSize-len(zBytes)), zBytes...)
+	ecdhPriv, err := priv.ECDH()
+	if err != nil {
+		panic("invalid private key")
+	}
+	zBytes, err := ecdhPriv.ECDH(ecdhPub)
+	if err != nil {
+		panic("public key not on same curve as private key")
 	}
 
 	reader := NewConcatKDF(crypto.SHA256, zBytes, algID, ptyUInfo, ptyVInfo, supPubInfo, []byte{})
@@ -65,17 +60,6 @@ func DeriveECDHES(alg string, apuData, apvData []byte, priv *ecdsa.PrivateKey, p
 	_, _ = reader.Read(key)
 
 	return key
-}
-
-// dSize returns the size in octets for a coordinate on a elliptic curve.
-func dSize(curve elliptic.Curve) int {
-	order := curve.Params().P
-	bitLen := order.BitLen()
-	size := bitLen / 8
-	if bitLen%8 != 0 {
-		size++
-	}
-	return size
 }
 
 func lengthPrefixed(data []byte) []byte {

--- a/jwk.go
+++ b/jwk.go
@@ -562,15 +562,17 @@ func (key rawJSONWebKey) ecPublicKey() (*ecdsa.PublicKey, error) {
 	x := key.X.bigInt()
 	y := key.Y.bigInt()
 
-	if !curve.IsOnCurve(x, y) {
-		return nil, errors.New("go-jose/go-jose: invalid EC key, X/Y are not on declared curve")
-	}
-
-	return &ecdsa.PublicKey{
+	pub := &ecdsa.PublicKey{
 		Curve: curve,
 		X:     x,
 		Y:     y,
-	}, nil
+	}
+
+	if _, err := pub.ECDH(); err != nil {
+		return nil, errors.New("go-jose/go-jose: invalid EC key, X/Y are not on declared curve")
+	}
+
+	return pub, nil
 }
 
 func fromEcPublicKey(pub *ecdsa.PublicKey) (*rawJSONWebKey, error) {
@@ -757,18 +759,20 @@ func (key rawJSONWebKey) ecPrivateKey() (*ecdsa.PrivateKey, error) {
 	x := key.X.bigInt()
 	y := key.Y.bigInt()
 
-	if !curve.IsOnCurve(x, y) {
-		return nil, errors.New("go-jose/go-jose: invalid EC key, X/Y are not on declared curve")
-	}
-
-	return &ecdsa.PrivateKey{
+	priv := &ecdsa.PrivateKey{
 		PublicKey: ecdsa.PublicKey{
 			Curve: curve,
 			X:     x,
 			Y:     y,
 		},
 		D: key.D.bigInt(),
-	}, nil
+	}
+
+	if _, err := priv.ECDH(); err != nil {
+		return nil, errors.New("go-jose/go-jose: invalid EC key, X/Y are not on declared curve")
+	}
+
+	return priv, nil
 }
 
 func fromEcPrivateKey(ec *ecdsa.PrivateKey) (*rawJSONWebKey, error) {

--- a/jwk.go
+++ b/jwk.go
@@ -768,8 +768,9 @@ func (key rawJSONWebKey) ecPrivateKey() (*ecdsa.PrivateKey, error) {
 		D: key.D.bigInt(),
 	}
 
-	if _, err := priv.ECDH(); err != nil {
-		return nil, errors.New("go-jose/go-jose: invalid EC key, X/Y are not on declared curve")
+	_, err := priv.ECDH()
+	if err != nil {
+		return nil, fmt.Errorf("go-jose/go-jose: invalid EC key: %w", err)
 	}
 
 	return priv, nil


### PR DESCRIPTION
Instead of doing explicit IsOnCurve checks, we can call ecdsa.ECDH()
which does the check for us.

Instead of performing the ECDH scalar multiplcation, we can call
ecdh.ECDH() to get the shared secret.

These have been available since Go 1.20, well within what we require.
