### PR TITLE
jwe: don't strip internal whitespace before parsing JSON

### DIFF
--- a/jwe.go
+++ b/jwe.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/go-jose/go-jose/v4/json"
 )
@@ -137,12 +138,12 @@ func ParseEncrypted(input string,
 	keyEncryptionAlgorithms []KeyAlgorithm,
 	contentEncryption []ContentEncryption,
 ) (*JSONWebEncryption, error) {
-	input = stripWhitespace(input)
-	if strings.HasPrefix(input, "{") {
+	trimmed := strings.TrimLeftFunc(input, unicode.IsSpace)
+	if strings.HasPrefix(trimmed, "{") {
 		return ParseEncryptedJSON(input, keyEncryptionAlgorithms, contentEncryption)
 	}
 
-	return ParseEncryptedCompact(input, keyEncryptionAlgorithms, contentEncryption)
+	return ParseEncryptedCompact(stripWhitespace(input), keyEncryptionAlgorithms, contentEncryption)
 }
 
 // ParseEncryptedJSON parses a message in JWE JSON Serialization.

--- a/jwe_test.go
+++ b/jwe_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"math/big"
 	"regexp"
@@ -853,5 +854,39 @@ func BenchmarkParseEncryptedCompat(b *testing.B) {
 		if _, err := ParseEncryptedCompact(msg, []KeyAlgorithm{RSA_OAEP}, []ContentEncryption{A128GCM}); err != nil {
 			panic(err)
 		}
+	}
+}
+
+func TestParseEncryptedJSONDoesNotRewriteMemberNames(t *testing.T) {
+	enc, err := NewEncrypter(A128GCM, Recipient{Algorithm: A128KW, Key: []byte("0123456789abcdef")}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := enc.Encrypt([]byte("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(obj.FullSerialize()), &fields); err != nil {
+		t.Fatal(err)
+	}
+
+	// A member name with internal whitespace must not be collapsed into a
+	// recognized JWE member ("unprotec ted" -> "unprotected").
+	raw := `{"unprotec ted":{"kid":"smuggled"}`
+	for _, k := range []string{"protected", "encrypted_key", "iv", "ciphertext", "tag"} {
+		if v, ok := fields[k]; ok {
+			raw += `,"` + k + `":` + string(v)
+		}
+	}
+	raw += `}`
+
+	parsed, err := ParseEncrypted(raw, []KeyAlgorithm{A128KW}, []ContentEncryption{A128GCM})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Header.KeyID != "" {
+		t.Errorf("ParseEncrypted exposed kid %q from a whitespace-mutated member name", parsed.Header.KeyID)
 	}
 }


### PR DESCRIPTION
## Summary

The JWE counterpart of #237, fixed for JWS in #239.

`ParseEncrypted` stripped whitespace from the whole input before dispatching between JWE JSON and compact serialization, which also removed whitespace inside JSON member names. JSON input is now passed to `ParseEncryptedJSON` unchanged after checking the first non-whitespace rune, while compact parsing keeps the existing whitespace stripping.

## Verification

- `go test ./... -run '^TestParseEncryptedJSONDoesNotRewriteMemberNames$' -count=1 -v`
- `go test ./... -count=1`
- `go build ./...`
