### PR TITLE
Reject mismatched JWE CEK lengths

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -428,6 +428,13 @@ func (ctx *genericEncrypter) Options() EncrypterOptions {
 	}
 }
 
+func validateContentEncryptionKeySize(cek []byte, cipher contentCipher) error {
+	if len(cek) != cipher.keySize() {
+		return ErrInvalidKeySize
+	}
+	return nil
+}
+
 // Decrypt and validate the object and return the plaintext. This
 // function does not support multi-recipient. If you desire multi-recipient
 // decryption use DecryptMulti instead.
@@ -492,6 +499,10 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 	recipientHeaders := obj.mergedHeaders(&recipient)
 
 	cek, err := decrypter.decryptKey(recipientHeaders, &recipient, generator)
+	if err != nil {
+		return nil, ErrCryptoFailure
+	}
+	err = validateContentEncryptionKeySize(cek, cipher)
 	if err != nil {
 		return nil, ErrCryptoFailure
 	}
@@ -572,6 +583,10 @@ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Heade
 
 		var cek []byte
 		cek, err = decrypter.decryptKey(recipientHeaders, &recipient, generator)
+		if err != nil {
+			continue
+		}
+		err = validateContentEncryptionKeySize(cek, cipher)
 		if err != nil {
 			continue
 		}

--- a/jwe_test.go
+++ b/jwe_test.go
@@ -785,6 +785,211 @@ func TestEmptyEncryptedKey(t *testing.T) {
 	}
 }
 
+func TestJWERejectsShortGCMCEKForDeclaredContentEncryption(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      []byte
+		declared ContentEncryption
+		actual   ContentEncryption
+	}{
+		{
+			name:     "A256GCM with A128GCM key",
+			key:      []byte("0123456789abcdef"),
+			declared: A256GCM,
+			actual:   A128GCM,
+		},
+		{
+			name:     "A192GCM with A128GCM key",
+			key:      []byte("0123456789abcdef"),
+			declared: A192GCM,
+			actual:   A128GCM,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			plaintext := []byte("content encrypted under a shorter CEK")
+			token := jweJSONWithMismatchedCEK(
+				t,
+				test.key,
+				plaintext,
+				test.declared,
+				test.actual,
+			)
+
+			parsed, err := ParseEncryptedJSON(
+				token,
+				[]KeyAlgorithm{DIRECT},
+				[]ContentEncryption{test.declared},
+			)
+			if err != nil {
+				t.Fatalf("ParseEncryptedJSON: %v", err)
+			}
+
+			_, err = parsed.Decrypt(test.key)
+			if err == nil {
+				t.Fatal("Decrypt accepted content encrypted under a shorter CEK")
+			}
+
+			_, _, _, err = parsed.DecryptMulti(test.key)
+			if err == nil {
+				t.Fatal("DecryptMulti accepted content encrypted under a shorter CEK")
+			}
+		})
+	}
+}
+
+func TestJWERejectsShortCBCHMACCEKForDeclaredContentEncryption(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      []byte
+		declared ContentEncryption
+	}{
+		{
+			name:     "A256CBC-HS512 with A128CBC-HS256 key",
+			key:      []byte("0123456789abcdef0123456789abcdef"),
+			declared: A256CBC_HS512,
+		},
+		{
+			name:     "A192CBC-HS384 with A128CBC-HS256 key",
+			key:      []byte("0123456789abcdef0123456789abcdef"),
+			declared: A192CBC_HS384,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			plaintext := []byte("content encrypted under a shorter CEK")
+			token := jweJSONWithMismatchedCBCHMACCEK(t, test.key, plaintext, test.declared)
+
+			parsed, err := ParseEncryptedJSON(
+				token,
+				[]KeyAlgorithm{DIRECT},
+				[]ContentEncryption{test.declared},
+			)
+			if err != nil {
+				t.Fatalf("ParseEncryptedJSON: %v", err)
+			}
+
+			_, err = parsed.Decrypt(test.key)
+			if err == nil {
+				t.Fatal("Decrypt accepted content encrypted under a shorter CEK")
+			}
+
+			_, _, _, err = parsed.DecryptMulti(test.key)
+			if err == nil {
+				t.Fatal("DecryptMulti accepted content encrypted under a shorter CEK")
+			}
+		})
+	}
+}
+
+func jweJSONWithMismatchedCEK(
+	t *testing.T,
+	key []byte,
+	plaintext []byte,
+	declared ContentEncryption,
+	actual ContentEncryption,
+) string {
+	t.Helper()
+
+	protected := rawHeader{}
+	err := protected.set(headerAlgorithm, DIRECT)
+	if err != nil {
+		t.Fatalf("set alg: %v", err)
+	}
+	err = protected.set(headerEncryption, declared)
+	if err != nil {
+		t.Fatalf("set enc: %v", err)
+	}
+
+	protectedJSON := mustSerializeJSON(protected)
+	protectedB64 := newBuffer(protectedJSON).base64()
+	cipher := getContentCipher(actual)
+	parts, err := cipher.encrypt(key, []byte(protectedB64), plaintext)
+	if err != nil {
+		t.Fatalf("encrypt content: %v", err)
+	}
+
+	raw := rawJSONWebEncryption{
+		Protected:  newBuffer(protectedJSON),
+		Iv:         newBuffer(parts.iv),
+		Ciphertext: newBuffer(parts.ciphertext),
+		Tag:        newBuffer(parts.tag),
+	}
+	return string(mustSerializeJSON(raw))
+}
+
+func jweJSONWithMismatchedCBCHMACCEK(
+	t *testing.T,
+	key []byte,
+	plaintext []byte,
+	declared ContentEncryption,
+) string {
+	t.Helper()
+
+	protected := rawHeader{}
+	err := protected.set(headerAlgorithm, DIRECT)
+	if err != nil {
+		t.Fatalf("set alg: %v", err)
+	}
+	err = protected.set(headerEncryption, declared)
+	if err != nil {
+		t.Fatalf("set enc: %v", err)
+	}
+
+	protectedJSON := mustSerializeJSON(protected)
+	protectedB64 := newBuffer(protectedJSON).base64()
+	cipher := getContentCipher(A128CBC_HS256)
+	parts, err := cipher.encrypt(key, []byte(protectedB64), plaintext)
+	if err != nil {
+		t.Fatalf("encrypt content: %v", err)
+	}
+
+	actualTagLen := len(parts.tag)
+	declaredTagLen := cbcTagLength(t, declared)
+	if declaredTagLen < actualTagLen {
+		t.Fatalf("declared tag length %d is shorter than actual tag length %d",
+			declaredTagLen, actualTagLen)
+	}
+
+	prefixLen := declaredTagLen - actualTagLen
+	if len(parts.ciphertext) < prefixLen {
+		t.Fatalf("ciphertext length %d is shorter than tag prefix length %d",
+			len(parts.ciphertext), prefixLen)
+	}
+
+	// Move ciphertext bytes into the tag field so the outer declared-tag length check
+	// passes while the inner A128CBC-HS256 AEAD still sees its original tag.
+	ciphertextPart := parts.ciphertext[:len(parts.ciphertext)-prefixLen]
+	tagPart := append([]byte{}, parts.ciphertext[len(parts.ciphertext)-prefixLen:]...)
+	tagPart = append(tagPart, parts.tag...)
+
+	raw := rawJSONWebEncryption{
+		Protected:  newBuffer(protectedJSON),
+		Iv:         newBuffer(parts.iv),
+		Ciphertext: newBuffer(ciphertextPart),
+		Tag:        newBuffer(tagPart),
+	}
+	return string(mustSerializeJSON(raw))
+}
+
+func cbcTagLength(t *testing.T, enc ContentEncryption) int {
+	t.Helper()
+
+	switch enc {
+	case A128CBC_HS256:
+		return 16
+	case A192CBC_HS384:
+		return 24
+	case A256CBC_HS512:
+		return 32
+	default:
+		t.Fatalf("unsupported CBC enc %q", enc)
+		return 0
+	}
+}
+
 func BenchmarkParseEncryptedCompat(b *testing.B) {
 	msg := "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkExMjhHQ00ifQ.dGVzdA.dGVzdA.dGVzdA.dGVzdA"
 	for range b.N {


### PR DESCRIPTION
## Summary

Fixes #265.

This patch rejects JWE Content Encryption Keys (CEKs) whose length does not match the
content cipher selected by `enc` before content decryption.
[RFC 7516 Section 4.1.2](https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.2)
defines `enc` as the content-encryption algorithm header parameter,
[RFC 7518 Section 5.3](https://www.rfc-editor.org/rfc/rfc7518.html#section-5.3)
defines `A128GCM`, `A192GCM`, and `A256GCM` as AES-GCM using 128-, 192-, and
256-bit keys, and
[RFC 7518 Section 5.2](https://www.rfc-editor.org/rfc/rfc7518.html#section-5.2)
defines `A128CBC-HS256`, `A192CBC-HS384`, and `A256CBC-HS512` with 256-, 384-, and
512-bit combined CEKs. The reported downgrade is that shorter AES-GCM and
AES-CBC-HMAC content can be accepted under longer declared algorithms because the
content cipher is constructed from the returned CEK before go-jose verifies that the
CEK length matches `enc`.

The implementation checks `contentCipher.keySize()` after direct-key selection or CEK
unwrap and before authenticated content decryption in both `Decrypt` and
`DecryptMulti`. It intentionally preserves valid decryptions and multi-recipient
fallback. The check is generic because the selected content cipher already defines the
required CEK length; the regressions cover both AES-GCM and AES-CBC-HMAC downgrade
cases.

## Verification

- Base: `go-jose/go-jose` `main` at `8d4e64dd6193f330ff4babb4038c99c56974abff`
- fail-first regression:
  `go test . -run '^TestJWERejectsShort(GCM|CBCHMAC)CEKForDeclaredContentEncryption$' -count=1 -v`
  fails on current `main` for the `A256GCM`/`A192GCM` and
  `A256CBC-HS512`/`A192CBC-HS384` subtests
- root-cause test:
  `go test . -run '^(TestJWERejectsShort(GCM|CBCHMAC)CEKForDeclaredContentEncryption|TestJWEDecryptWithoutProtectedHeader|TestJWENilProtected)$' -count=1 -v`:
  passes
- repo checks: `go test ./... -count=1`: passes
- formatting/static checks: `gofmt -l crypter.go jwe_test.go`: no output;
  `git diff --check upstream/main...HEAD`: passes
