### PR TITLE
Reject wrong-curve ECDSA JWS verification keys

### DIFF
--- a/asymmetric.go
+++ b/asymmetric.go
@@ -21,6 +21,7 @@ import (
 	"crypto/aes"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -507,24 +508,14 @@ func (ctx edEncrypterVerifier) verifyPayload(payload []byte, signature []byte, a
 
 // Sign the given payload
 func (ctx ecDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm) (Signature, error) {
-	var expectedBitSize int
-	var hash crypto.Hash
-
-	switch alg {
-	case ES256:
-		expectedBitSize = 256
-		hash = crypto.SHA256
-	case ES384:
-		expectedBitSize = 384
-		hash = crypto.SHA384
-	case ES512:
-		expectedBitSize = 521
-		hash = crypto.SHA512
+	keyBytes, expectedCurve, hash, err := ecdsaSignatureDetails(alg)
+	if err != nil {
+		return Signature{}, err
 	}
 
-	curveBits := ctx.privateKey.Curve.Params().BitSize
-	if expectedBitSize != curveBits {
-		return Signature{}, fmt.Errorf("go-jose/go-jose: expected %d bit key, got %d bits instead", expectedBitSize, curveBits)
+	err = validateECDSACurve(ctx.privateKey.Curve, expectedCurve)
+	if err != nil {
+		return Signature{}, err
 	}
 
 	hasher := hash.New()
@@ -536,11 +527,6 @@ func (ctx ecDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm)
 	r, s, err := ecdsa.Sign(randReader, ctx.privateKey, hashed)
 	if err != nil {
 		return Signature{}, err
-	}
-
-	keyBytes := curveBits / 8
-	if curveBits%8 > 0 {
-		keyBytes++
 	}
 
 	// We serialize the outputs (r and s) into big-endian byte arrays and pad
@@ -564,21 +550,14 @@ func (ctx ecDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm)
 
 // Verify the given payload
 func (ctx ecEncrypterVerifier) verifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error {
-	var keySize int
-	var hash crypto.Hash
+	keySize, expectedCurve, hash, err := ecdsaSignatureDetails(alg)
+	if err != nil {
+		return err
+	}
 
-	switch alg {
-	case ES256:
-		keySize = 32
-		hash = crypto.SHA256
-	case ES384:
-		keySize = 48
-		hash = crypto.SHA384
-	case ES512:
-		keySize = 66
-		hash = crypto.SHA512
-	default:
-		return ErrUnsupportedAlgorithm
+	err = validateECDSACurve(ctx.publicKey.Curve, expectedCurve)
+	if err != nil {
+		return err
 	}
 
 	if len(signature) != 2*keySize {
@@ -599,5 +578,29 @@ func (ctx ecEncrypterVerifier) verifyPayload(payload []byte, signature []byte, a
 		return errors.New("go-jose/go-jose: ecdsa signature failed to verify")
 	}
 
+	return nil
+}
+
+func ecdsaSignatureDetails(alg SignatureAlgorithm) (int, string, crypto.Hash, error) {
+	switch alg {
+	case ES256:
+		return 32, "P-256", crypto.SHA256, nil
+	case ES384:
+		return 48, "P-384", crypto.SHA384, nil
+	case ES512:
+		return 66, "P-521", crypto.SHA512, nil
+	default:
+		return 0, "", 0, ErrUnsupportedAlgorithm
+	}
+}
+
+func validateECDSACurve(curve elliptic.Curve, expected string) error {
+	actual, err := curveName(curve)
+	if err != nil {
+		return err
+	}
+	if expected != actual {
+		return fmt.Errorf("go-jose/go-jose: expected %s key, got %s instead", expected, actual)
+	}
 	return nil
 }

--- a/asymmetric_test.go
+++ b/asymmetric_test.go
@@ -21,9 +21,13 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
 	"errors"
 	"github.com/go-jose/go-jose/v4/json"
 	"io"
+	"math/big"
 	"testing"
 )
 
@@ -63,6 +67,173 @@ func TestEd25519(t *testing.T) {
 	if err == nil {
 		t.Error("should not error trying to verify payload")
 	}
+}
+
+func TestECDSAVerifyRejectsWrongCurveForAlgorithm(t *testing.T) {
+	testCases := []struct {
+		name      string
+		curve     elliptic.Curve
+		tokenAlg  SignatureAlgorithm
+		hashInput func([]byte) []byte
+		width     int
+	}{
+		{
+			name:     "ES384 with P-256 key",
+			curve:    elliptic.P256(),
+			tokenAlg: ES384,
+			hashInput: func(input []byte) []byte {
+				sum := sha512.Sum384(input)
+				return sum[:]
+			},
+			width: 48,
+		},
+		{
+			name:     "ES512 with P-256 key",
+			curve:    elliptic.P256(),
+			tokenAlg: ES512,
+			hashInput: func(input []byte) []byte {
+				sum := sha512.Sum512(input)
+				return sum[:]
+			},
+			width: 66,
+		},
+		{
+			name:     "ES512 with P-384 key",
+			curve:    elliptic.P384(),
+			tokenAlg: ES512,
+			hashInput: func(input []byte) []byte {
+				sum := sha512.Sum512(input)
+				return sum[:]
+			},
+			width: 66,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := ecdsa.GenerateKey(tc.curve, rand.Reader)
+			if err != nil {
+				t.Fatalf("generate test key: %v", err)
+			}
+			payload := []byte(`{"sub":"attacker","admin":true}`)
+			protected := []byte(`{"alg":"` + string(tc.tokenAlg) + `","kid":"ecdsa-key"}`)
+			protectedB64 := base64.RawURLEncoding.EncodeToString(protected)
+			payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+			authData := []byte(protectedB64 + "." + payloadB64)
+			digest := tc.hashInput(authData)
+
+			r, s, err := ecdsa.Sign(rand.Reader, key, digest)
+			if err != nil {
+				t.Fatalf("sign payload: %v", err)
+			}
+			signature := ecdsaSignature(t, r, s, tc.width)
+			compact := protectedB64 + "." + payloadB64 + "." +
+				base64.RawURLEncoding.EncodeToString(signature)
+
+			jws, err := ParseSigned(compact, []SignatureAlgorithm{tc.tokenAlg})
+			if err != nil {
+				t.Fatalf("ParseSigned: %v", err)
+			}
+			jwks := JSONWebKeySet{Keys: []JSONWebKey{{
+				Key:       &key.PublicKey,
+				KeyID:     "ecdsa-key",
+				Algorithm: string(tc.tokenAlg),
+			}}}
+			verified, err := jws.Verify(jwks)
+			if err == nil {
+				t.Fatalf("Verify accepted wrong-curve payload %q", verified)
+			}
+		})
+	}
+}
+
+func TestECDSAVerifyRejectsNonJWACurve(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate P-256 key: %v", err)
+	}
+	payload := []byte(`{"sub":"attacker","admin":true}`)
+	protected := []byte(`{"alg":"ES256","kid":"ecdsa-key"}`)
+	protectedB64 := base64.RawURLEncoding.EncodeToString(protected)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+	authData := []byte(protectedB64 + "." + payloadB64)
+	digest := sha256.Sum256(authData)
+
+	r, s, err := ecdsa.Sign(rand.Reader, key, digest[:])
+	if err != nil {
+		t.Fatalf("sign payload: %v", err)
+	}
+	signature := ecdsaSignature(t, r, s, 32)
+	compact := protectedB64 + "." + payloadB64 + "." +
+		base64.RawURLEncoding.EncodeToString(signature)
+
+	jws, err := ParseSigned(compact, []SignatureAlgorithm{ES256})
+	if err != nil {
+		t.Fatalf("ParseSigned: %v", err)
+	}
+	publicKey := key.PublicKey
+	publicKey.Curve = wrappedCurve{Curve: key.Curve}
+	jwks := JSONWebKeySet{Keys: []JSONWebKey{{
+		Key:       &publicKey,
+		KeyID:     "ecdsa-key",
+		Algorithm: string(ES256),
+	}}}
+	verified, err := jws.Verify(jwks)
+	if err == nil {
+		t.Fatalf("Verify accepted a non-JWA curve for ES256 payload %q", verified)
+	}
+}
+
+func TestECDSAVerifyRejectsWrongDigestForSameCurveConfusion(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate P-384 key: %v", err)
+	}
+	payload := []byte(`{"sub":"attacker","admin":true}`)
+	protected := []byte(`{"alg":"ES384","kid":"ecdsa-key"}`)
+	protectedB64 := base64.RawURLEncoding.EncodeToString(protected)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+	authData := []byte(protectedB64 + "." + payloadB64)
+	digest := sha256.Sum256(authData)
+
+	r, s, err := ecdsa.Sign(rand.Reader, key, digest[:])
+	if err != nil {
+		t.Fatalf("sign payload with SHA-256 control digest: %v", err)
+	}
+	signature := ecdsaSignature(t, r, s, 48)
+	compact := protectedB64 + "." + payloadB64 + "." +
+		base64.RawURLEncoding.EncodeToString(signature)
+
+	jws, err := ParseSigned(compact, []SignatureAlgorithm{ES384})
+	if err != nil {
+		t.Fatalf("ParseSigned: %v", err)
+	}
+	jwks := JSONWebKeySet{Keys: []JSONWebKey{{
+		Key:   &key.PublicKey,
+		KeyID: "ecdsa-key",
+	}}}
+	_, err = jws.Verify(jwks)
+	if err == nil {
+		t.Fatal("ES384 token verified even though signature used SHA-256")
+	}
+}
+
+func ecdsaSignature(t *testing.T, r *big.Int, s *big.Int, size int) []byte {
+	t.Helper()
+
+	out := make([]byte, 2*size)
+	rBytes := r.Bytes()
+	sBytes := s.Bytes()
+	if len(rBytes) > size || len(sBytes) > size {
+		t.Fatalf("signature integer does not fit requested width")
+	}
+	copy(out[size-len(rBytes):size], rBytes)
+	copy(out[2*size-len(sBytes):], sBytes)
+	return out
+}
+
+type wrappedCurve struct {
+	elliptic.Curve
 }
 
 func TestInvalidAlgorithmsRSA(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #267.

Reject ECDSA verification keys whose curve does not match the declared JWS `alg`
value. [RFC 7518 Section 3.4](https://www.rfc-editor.org/rfc/rfc7518.html#section-3.4)
maps `ES256`, `ES384`, and `ES512` to P-256, P-384, and P-521 respectively; the
verifier now enforces that mapping before calling `ecdsa.Verify`, and signing and
verification share the same mapping.

This closes the case where a caller that accepts only `ES384` or `ES512` can still
verify a token using a trusted P-256 or P-384 key from a JWKS. The shared mapping also
rejects unsupported curve wrappers instead of accepting arbitrary curves that only
match an RFC 7518 curve by bit size.

## Verification

- Base: `go-jose/go-jose` `main` at `8d4e64dd6193f330ff4babb4038c99c56974abff`
- Fail-first regression:
  `go test . -run '^TestECDSAVerifyRejects(WrongCurveForAlgorithm|WrongDigestForSameCurveConfusion)$' -count=1 -v`
  fails on current `main` for the three wrong-curve subtests while the wrong-digest
  control passes
- Focused regression:
  `go test . -run '^TestECDSAVerifyRejects(WrongCurveForAlgorithm|NonJWACurve|WrongDigestForSameCurveConfusion)$' -count=1 -v`:
  passes
- Repo checks: `go build -v ./...`: passes; `go test ./... -count=1`: passes
- Additional checks: `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`: no
  vulnerabilities found; `gofmt -l asymmetric.go asymmetric_test.go`: no output;
  `git diff --check upstream/main...HEAD`: passes
