### PR TITLE
Ignore unrecognised key types in a JWK Set (RFC 7517 §5)

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -371,6 +371,30 @@ func (s *JSONWebKeySet) Key(kid string) []JSONWebKey {
 	return keys
 }
 
+// UnmarshalJSON reads a key set, skipping any member whose key type it does not
+// understand rather than failing the whole set. This follows RFC 7517, Section 5:
+// "Implementations SHOULD ignore JWKs within a JWK Set that use "kty" (key type)
+// values that are not understood by them". It matters as new algorithms (for
+// example post-quantum keys) begin appearing in published key sets alongside
+// classical keys.
+func (s *JSONWebKeySet) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Keys []json.RawMessage `json:"keys"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	s.Keys = make([]JSONWebKey, 0, len(raw.Keys))
+	for _, rawKey := range raw.Keys {
+		var key JSONWebKey
+		if err := key.UnmarshalJSON(rawKey); err != nil {
+			continue
+		}
+		s.Keys = append(s.Keys, key)
+	}
+	return nil
+}
+
 const rsaThumbprintTemplate = `{"e":"%s","kty":"RSA","n":"%s"}`
 const ecThumbprintTemplate = `{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`
 const edThumbprintTemplate = `{"crv":"%s","kty":"OKP","x":"%s"}`

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -1184,3 +1184,18 @@ func TestJWKPaddingY(t *testing.T) {
 		t.Errorf("Expected key to be invalid, but it was valid.")
 	}
 }
+
+func TestJSONWebKeySetIgnoresUnknownKeyType(t *testing.T) {
+	// RFC 7517 Section 5: an unrecognised "kty" in a set is ignored, not fatal.
+	mixed := []byte(`{"keys":[{"kty":"AKP","alg":"ML-DSA-65","pub":"AAAA"},{"kty":"oct","k":"c2VjcmV0","kid":"classical"}]}`)
+	var set JSONWebKeySet
+	if err := set.UnmarshalJSON(mixed); err != nil {
+		t.Fatalf("a set containing an unknown kty should not fail: %v", err)
+	}
+	if len(set.Keys) != 1 {
+		t.Fatalf("expected 1 surviving key, got %d", len(set.Keys))
+	}
+	if len(set.Key("classical")) != 1 {
+		t.Fatal("the classical key must survive alongside an unknown one")
+	}
+}


### PR DESCRIPTION
### What

Adds `JSONWebKeySet.UnmarshalJSON` so that unmarshalling a key set **skips** a member whose `kty` it does not understand, instead of failing the entire set. Single-key `JSONWebKey.UnmarshalJSON` behaviour is unchanged.

### Why

RFC 7517, Section 5: *"Implementations SHOULD ignore JWKs within a JWK Set that use 'kty' (key type) values that are not understood by them."* Today, `json.Unmarshal` into a `JSONWebKeySet` fails the whole set on one unrecognised key (`unsupported key type/format`), so a single unknown key stops the classical keys next to it from being usable.

This is becoming a live problem as post-quantum keys (ML-DSA, `kty:"AKP"`, RFC 9964) start appearing in published JWKS alongside RSA/EC keys: a consumer on the current behaviour stops verifying **every** signature from that issuer, including the classical ones, the moment such a key is published. It relates to the issue I raised in #276.

### Change

- New `(*JSONWebKeySet).UnmarshalJSON`: decode `keys` element by element, skip members that fail to unmarshal, keep the rest.
- Regression test `TestJSONWebKeySetIgnoresUnknownKeyType`.

Full test suite passes. Happy to adjust (e.g. surface the skipped count, or gate behind an option) if you'd prefer.