### PR TITLE
jwt: reject out-of-range NumericDate values

### DIFF
--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -24,6 +24,11 @@ import (
 	"github.com/go-jose/go-jose/v4/json"
 )
 
+// maxNumericDate bounds an accepted NumericDate (in seconds). It is far past
+// any real timestamp but safely below where an int64 conversion or time.Unix
+// would overflow and wrap Time() to a bogus instant.
+const maxNumericDate = 1 << 62
+
 // Claims represents public claim values (as specified in RFC 7519).
 type Claims struct {
 	Issuer    string       `json:"iss,omitempty"`
@@ -66,6 +71,16 @@ func (n *NumericDate) UnmarshalJSON(b []byte) error {
 
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
+		return ErrUnmarshalNumericDate
+	}
+
+	// Reject values large enough to overflow either the int64 conversion below
+	// or time.Unix in Time(). time.Unix adds a ~62e9-second offset internally,
+	// so a value near the int64 limit wraps and compares as a time in the
+	// past; for "nbf" that lets a not-yet-valid token pass the not-before
+	// check instead of being rejected. maxNumericDate (2^62 seconds) is far
+	// beyond any real timestamp yet safely below both overflow points.
+	if f >= maxNumericDate || f <= -maxNumericDate {
 		return ErrUnmarshalNumericDate
 	}
 

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -120,6 +120,32 @@ func TestNumericDate(t *testing.T) {
 	}
 }
 
+func TestNumericDateOutOfRange(t *testing.T) {
+	// Values large enough to overflow the int64 conversion or time.Unix wrap
+	// to a bogus instant, so they must be rejected rather than stored. The
+	// 9.22e18 case fits in an int64 but still overflows time.Unix's internal
+	// offset.
+	for _, raw := range []string{"1e19", "-1e19", "9.3e18", "9223372036800000000", "1e300"} {
+		var nd NumericDate
+		assert.ErrorIs(t, nd.UnmarshalJSON([]byte(raw)), ErrUnmarshalNumericDate)
+	}
+
+	// In-range values, including fractional seconds, still parse.
+	var nd NumericDate
+	if assert.NoError(t, nd.UnmarshalJSON([]byte("1451606400.5"))) {
+		assert.Equal(t, int64(1451606400), int64(nd))
+	}
+}
+
+// TestOutOfRangeNbfNotBeforeCheck guards against an out-of-range "nbf" being
+// silently accepted. Before the range check in UnmarshalJSON, {"nbf": 1e19}
+// overflowed to a value that time.Unix wrapped into the past, so Validate
+// accepted a token that is not yet valid; it must now fail to decode.
+func TestOutOfRangeNbfNotBeforeCheck(t *testing.T) {
+	var c Claims
+	assert.ErrorIs(t, json.Unmarshal([]byte(`{"nbf": 1e19}`), &c), ErrUnmarshalNumericDate)
+}
+
 func TestEncodeClaimsTimeValues(t *testing.T) {
 	now := time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)
 


### PR DESCRIPTION
`Claims.Validate` accepts a token whose `nbf` is set to an out-of-range number such as `1e19`.

`NumericDate.UnmarshalJSON` does `NumericDate(f)` on the `ParseFloat` result with no range check. A value large enough to overflow the int64 conversion, or `time.Unix`'s internal offset in `Time()`, wraps to an instant in the past. So `{"nbf": 1e19}` is treated as already reached and the not-before check passes instead of returning `ErrNotValidYet`; `{"exp": 1e19}` conversely reads as expired.

What changed:
- jwt/claims.go: reject a `NumericDate` past a bound (2^62 seconds) that is far beyond any real timestamp but safely below both overflow points, returning `ErrUnmarshalNumericDate` (same as a non-numeric value). In-range values, including fractional seconds, are unchanged.
- jwt/claims_test.go: add `TestNumericDateOutOfRange` and `TestOutOfRangeNbfNotBeforeCheck`.

`nbf`/`exp` live in the signed payload, so this is not a signature bypass, just a validation-correctness fix for malformed dates.

Checked (go1.26.4):
- `go test ./...`
- `go vet ./jwt/`, `gofmt -l`
- The two new tests fail on the unpatched claims.go and pass with the change.