### PR TITLE
jwk: return ErrUnsupportedEllipticCurve for unknown EC curves

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -541,7 +541,7 @@ func (key rawJSONWebKey) ecPublicKey() (*ecdsa.PublicKey, error) {
 	case "P-521":
 		curve = elliptic.P521()
 	default:
-		return nil, fmt.Errorf("go-jose/go-jose: %w '%s'", ErrUnsupportedEllipticCurve, key.Crv)
+		return nil, fmt.Errorf("%w: '%s'", ErrUnsupportedEllipticCurve, key.Crv)
 	}
 
 	if key.X == nil || key.Y == nil {
@@ -720,7 +720,7 @@ func (key rawJSONWebKey) ecPrivateKey() (*ecdsa.PrivateKey, error) {
 	case "P-521":
 		curve = elliptic.P521()
 	default:
-		return nil, fmt.Errorf("go-jose/go-jose: %w '%s'", ErrUnsupportedEllipticCurve, key.Crv)
+		return nil, fmt.Errorf("%w: '%s'", ErrUnsupportedEllipticCurve, key.Crv)
 	}
 
 	var missing []string

--- a/jwk.go
+++ b/jwk.go
@@ -541,7 +541,7 @@ func (key rawJSONWebKey) ecPublicKey() (*ecdsa.PublicKey, error) {
 	case "P-521":
 		curve = elliptic.P521()
 	default:
-		return nil, fmt.Errorf("go-jose/go-jose: unsupported elliptic curve '%s'", key.Crv)
+		return nil, fmt.Errorf("go-jose/go-jose: %w '%s'", ErrUnsupportedEllipticCurve, key.Crv)
 	}
 
 	if key.X == nil || key.Y == nil {
@@ -720,7 +720,7 @@ func (key rawJSONWebKey) ecPrivateKey() (*ecdsa.PrivateKey, error) {
 	case "P-521":
 		curve = elliptic.P521()
 	default:
-		return nil, fmt.Errorf("go-jose/go-jose: unsupported elliptic curve '%s'", key.Crv)
+		return nil, fmt.Errorf("go-jose/go-jose: %w '%s'", ErrUnsupportedEllipticCurve, key.Crv)
 	}
 
 	var missing []string

--- a/jwk.go
+++ b/jwk.go
@@ -541,7 +541,7 @@ func (key rawJSONWebKey) ecPublicKey() (*ecdsa.PublicKey, error) {
 	case "P-521":
 		curve = elliptic.P521()
 	default:
-		return nil, fmt.Errorf("%w: '%s'", ErrUnsupportedEllipticCurve, key.Crv)
+		return nil, ErrUnsupportedEllipticCurve
 	}
 
 	if key.X == nil || key.Y == nil {
@@ -720,7 +720,7 @@ func (key rawJSONWebKey) ecPrivateKey() (*ecdsa.PrivateKey, error) {
 	case "P-521":
 		curve = elliptic.P521()
 	default:
-		return nil, fmt.Errorf("%w: '%s'", ErrUnsupportedEllipticCurve, key.Crv)
+		return nil, ErrUnsupportedEllipticCurve
 	}
 
 	var missing []string

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -688,6 +688,22 @@ func TestJWKUnsupported(t *testing.T) {
 	}
 }
 
+// TestJWKUnsupportedEllipticCurve checks that an unknown EC curve returns
+// ErrUnsupportedEllipticCurve (via errors.Is), for both public and private JWKs.
+func TestJWKUnsupportedEllipticCurve(t *testing.T) {
+	cases := []string{
+		`{"kty":"EC","crv":"secp256k1","x":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","y":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`,
+		`{"kty":"EC","crv":"secp256k1","x":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","y":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","d":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`,
+	}
+	for _, raw := range cases {
+		var jwk JSONWebKey
+		err := jwk.UnmarshalJSON([]byte(raw))
+		if !errors.Is(err, ErrUnsupportedEllipticCurve) {
+			t.Errorf("expected ErrUnsupportedEllipticCurve, got: %v", err)
+		}
+	}
+}
+
 // Test vectors from RFC 7520
 var cookbookJWKs = []string{
 	// EC Public


### PR DESCRIPTION
## Summary
- Unknown EC curves in JWK unmarshal now return `ErrUnsupportedEllipticCurve` (via `%w`) from `ecPublicKey` / `ecPrivateKey`.
- Adds a unit test for public and private JWKs with `crv: secp256k1`.

Fixes #273

## Test plan
- [x] `go test -count=1 -run TestJWKUnsupportedEllipticCurve .` fails on unmodified code, passes with the fix
- [x] `go test -count=1 ./...`
