### PR TITLE
Remove stripWhitespace from JWS/JWE parsing

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -24,8 +24,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"strings"
-	"unicode"
 
 	"github.com/go-jose/go-jose/v4/json"
 )
@@ -52,18 +50,6 @@ func mustSerializeJSON(value interface{}) []byte {
 		panic("Tried to serialize a nil pointer.")
 	}
 	return out
-}
-
-// Strip all newlines and whitespace
-func stripWhitespace(data string) string {
-	buf := strings.Builder{}
-	buf.Grow(len(data))
-	for _, r := range data {
-		if !unicode.IsSpace(r) {
-			buf.WriteRune(r)
-		}
-	}
-	return buf.String()
 }
 
 // Perform compression based on algorithm

--- a/jwe.go
+++ b/jwe.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"unicode"
 
 	"github.com/go-jose/go-jose/v4/json"
 )
@@ -138,12 +137,12 @@ func ParseEncrypted(input string,
 	keyEncryptionAlgorithms []KeyAlgorithm,
 	contentEncryption []ContentEncryption,
 ) (*JSONWebEncryption, error) {
-	trimmed := strings.TrimLeftFunc(input, unicode.IsSpace)
+	trimmed := strings.TrimSpace(input)
 	if strings.HasPrefix(trimmed, "{") {
-		return ParseEncryptedJSON(input, keyEncryptionAlgorithms, contentEncryption)
+		return ParseEncryptedJSON(trimmed, keyEncryptionAlgorithms, contentEncryption)
 	}
 
-	return ParseEncryptedCompact(input, keyEncryptionAlgorithms, contentEncryption)
+	return ParseEncryptedCompact(trimmed, keyEncryptionAlgorithms, contentEncryption)
 }
 
 // ParseEncryptedJSON parses a message in JWE JSON Serialization.

--- a/jwe.go
+++ b/jwe.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/go-jose/go-jose/v4/json"
 )
@@ -137,8 +138,8 @@ func ParseEncrypted(input string,
 	keyEncryptionAlgorithms []KeyAlgorithm,
 	contentEncryption []ContentEncryption,
 ) (*JSONWebEncryption, error) {
-	input = stripWhitespace(input)
-	if strings.HasPrefix(input, "{") {
+	trimmed := strings.TrimLeftFunc(input, unicode.IsSpace)
+	if strings.HasPrefix(trimmed, "{") {
 		return ParseEncryptedJSON(input, keyEncryptionAlgorithms, contentEncryption)
 	}
 

--- a/jws.go
+++ b/jws.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"unicode"
 
 	"github.com/go-jose/go-jose/v4/json"
 )
@@ -90,12 +89,12 @@ func ParseSigned(
 	signature string,
 	signatureAlgorithms []SignatureAlgorithm,
 ) (*JSONWebSignature, error) {
-	trimmed := strings.TrimLeftFunc(signature, unicode.IsSpace)
+	trimmed := strings.TrimSpace(signature)
 	if strings.HasPrefix(trimmed, "{") {
-		return ParseSignedJSON(signature, signatureAlgorithms)
+		return ParseSignedJSON(trimmed, signatureAlgorithms)
 	}
 
-	return parseSignedCompact(signature, nil, signatureAlgorithms)
+	return parseSignedCompact(trimmed, nil, signatureAlgorithms)
 }
 
 // ParseSignedCompact parses a message in JWS Compact Serialization. Validation fails if the JWS is
@@ -133,7 +132,7 @@ func ParseDetached(
 	if payload == nil {
 		return nil, errors.New("go-jose/go-jose: nil payload")
 	}
-	return parseSignedCompact(signature, payload, signatureAlgorithms)
+	return parseSignedCompact(strings.TrimSpace(signature), payload, signatureAlgorithms)
 }
 
 // Get a header value

--- a/jws.go
+++ b/jws.go
@@ -95,7 +95,7 @@ func ParseSigned(
 		return ParseSignedJSON(signature, signatureAlgorithms)
 	}
 
-	return parseSignedCompact(stripWhitespace(signature), nil, signatureAlgorithms)
+	return parseSignedCompact(signature, nil, signatureAlgorithms)
 }
 
 // ParseSignedCompact parses a message in JWS Compact Serialization. Validation fails if the JWS is
@@ -133,7 +133,7 @@ func ParseDetached(
 	if payload == nil {
 		return nil, errors.New("go-jose/go-jose: nil payload")
 	}
-	return parseSignedCompact(stripWhitespace(signature), payload, signatureAlgorithms)
+	return parseSignedCompact(signature, payload, signatureAlgorithms)
 }
 
 // Get a header value

--- a/jws_test.go
+++ b/jws_test.go
@@ -852,3 +852,26 @@ func TestParseSignedDoesNotStripCompactWhitespace(t *testing.T) {
 		t.Fatal("ParseSignedCompact accepted compact serialization with internal whitespace")
 	}
 }
+
+func TestParseSignedTrimsOuterWhitespace(t *testing.T) {
+	key := []byte("0123456789ABCDEF0123456789ABCDEF")
+	signer, err := NewSigner(SigningKey{Algorithm: HS256, Key: key}, nil)
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	obj, err := signer.Sign([]byte("payload"))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	compact, err := obj.CompactSerialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize: %v", err)
+	}
+	// Leading/trailing whitespace (e.g. a trailing newline from a file or env var) is
+	// common and doesn't create the JSON-member-smuggling risk internal stripping did
+	// (go-jose/go-jose#237), so ParseSigned should still tolerate it.
+	padded := "\n  " + compact + "  \n"
+	if _, err := ParseSigned(padded, []SignatureAlgorithm{HS256}); err != nil {
+		t.Fatalf("ParseSigned rejected compact serialization with outer whitespace: %v", err)
+	}
+}

--- a/jws_test.go
+++ b/jws_test.go
@@ -829,3 +829,26 @@ func BenchmarkParseSignedCompat(b *testing.B) {
 		}
 	}
 }
+
+func TestParseSignedDoesNotStripCompactWhitespace(t *testing.T) {
+	key := []byte("0123456789ABCDEF0123456789ABCDEF")
+	signer, err := NewSigner(SigningKey{Algorithm: HS256, Key: key}, nil)
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	obj, err := signer.Sign([]byte("payload"))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	compact, err := obj.CompactSerialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize: %v", err)
+	}
+	spaced := strings.Replace(compact, ".", " . ", 1)
+	if _, err := ParseSigned(spaced, []SignatureAlgorithm{HS256}); err == nil {
+		t.Fatal("ParseSigned accepted compact serialization with internal whitespace")
+	}
+	if _, err := ParseSignedCompact(spaced, []SignatureAlgorithm{HS256}); err == nil {
+		t.Fatal("ParseSignedCompact accepted compact serialization with internal whitespace")
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -22,7 +22,22 @@ import (
 	"encoding/hex"
 	"math/big"
 	"regexp"
+	"strings"
+	"unicode"
 )
+
+// stripWhitespace is a test helper for formatting multi-line RFC vectors.
+// Production parsers no longer strip whitespace (see #244).
+func stripWhitespace(data string) string {
+	var buf strings.Builder
+	buf.Grow(len(data))
+	for _, r := range data {
+		if !unicode.IsSpace(r) {
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
+}
 
 // Reset random reader to original value
 func resetRandReader() {


### PR DESCRIPTION
## Summary
Removes production `stripWhitespace` from JWS/JWE parsing, as discussed in #244.

`ParseEncrypted` now matches `ParseSigned`: only leading whitespace is trimmed to tell JSON from compact. Compact tokens with internal spaces (for example `a . b . c`) are no longer accepted. A test-only helper remains for multi-line RFC vectors.

`go test ./...` passes.

Fixes #244

Edit: leading/trailing whitespace tolerance (e.g. a trailing newline from a file or env var) was restored in a follow-up commit — see the commit history for details, since dropping it entirely wasn't part of either #237 or #244's ask.
