### PR TITLE
Switch to using crypto.SignMessage instead of calling (crypto.Signer).Sign.

### DIFF
--- a/cryptosigner/cryptosigner.go
+++ b/cryptosigner/cryptosigner.go
@@ -87,22 +87,13 @@ func (s *cryptoSigner) SignPayload(payload []byte, alg jose.SignatureAlgorithm) 
 		return nil, jose.ErrUnsupportedAlgorithm
 	}
 
-	var hashed []byte
-	if hash != crypto.Hash(0) {
-		hasher := hash.New()
-		if _, err := hasher.Write(payload); err != nil {
-			return nil, err
-		}
-		hashed = hasher.Sum(nil)
-	}
-
 	var (
 		out []byte
 		err error
 	)
 	switch alg {
 	case jose.EdDSA:
-		out, err = s.signer.Sign(s.rand, payload, crypto.Hash(0))
+		out, err = crypto.SignMessage(s.signer, s.rand, payload, crypto.Hash(0))
 	case jose.ES256, jose.ES384, jose.ES512:
 		var byteLen int
 		switch alg {
@@ -114,7 +105,7 @@ func (s *cryptoSigner) SignPayload(payload []byte, alg jose.SignatureAlgorithm) 
 			byteLen = 66
 		}
 		var b []byte
-		b, err = s.signer.Sign(s.rand, hashed, hash)
+		b, err = crypto.SignMessage(s.signer, s.rand, payload, hash)
 		if err != nil {
 			return nil, err
 		}
@@ -136,9 +127,9 @@ func (s *cryptoSigner) SignPayload(payload []byte, alg jose.SignatureAlgorithm) 
 
 		out = append(out, sBytesPadded...)
 	case jose.RS256, jose.RS384, jose.RS512:
-		out, err = s.signer.Sign(s.rand, hashed, hash)
+		out, err = crypto.SignMessage(s.signer, s.rand, payload, hash)
 	case jose.PS256, jose.PS384, jose.PS512:
-		out, err = s.signer.Sign(s.rand, hashed, &rsa.PSSOptions{
+		out, err = crypto.SignMessage(s.signer, s.rand, payload, &rsa.PSSOptions{
 			SaltLength: rsa.PSSSaltLengthAuto,
 			Hash:       hash,
 		})

--- a/cryptosigner/cryptosigner_test.go
+++ b/cryptosigner/cryptosigner_test.go
@@ -45,7 +45,7 @@ func TestRoundtripsJWSCryptoSigner(t *testing.T) {
 		signingKey, verificationKey := generateSigningTestKey(alg)
 
 		for i, serializer := range serializers {
-			err := roundtripJWS(alg, serializer, Opaque(signingKey.(crypto.Signer)), verificationKey)
+			err := roundtripJWS(alg, serializer, Opaque(signingKey), verificationKey)
 			if err != nil {
 				t.Error(err, alg, i)
 			}
@@ -113,7 +113,20 @@ func roundtripJWS(sigAlg jose.SignatureAlgorithm, serializer func(*jose.JSONWebS
 	return nil
 }
 
-func generateSigningTestKey(sigAlg jose.SignatureAlgorithm) (sig, ver interface{}) {
+// messageSigner is a wrapper around crypto.Signer that errors out if Sign is inadvertently preferred over SignMessage.
+type messageSigner struct {
+	crypto.Signer
+}
+
+func (m messageSigner) SignMessage(rand io.Reader, msg []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return crypto.SignMessage(m.Signer, rand, msg, opts)
+}
+
+func (m messageSigner) Sign(io.Reader, []byte, crypto.SignerOpts) ([]byte, error) {
+	return nil, errors.New("not using SignMessage")
+}
+
+func generateSigningTestKey(sigAlg jose.SignatureAlgorithm) (sig crypto.Signer, ver interface{}) {
 	switch sigAlg {
 	case jose.EdDSA:
 		ver, sig, _ = ed25519.GenerateKey(rand.Reader)
@@ -136,6 +149,7 @@ func generateSigningTestKey(sigAlg jose.SignatureAlgorithm) (sig, ver interface{
 	default:
 		panic("Must update test case")
 	}
+	sig = messageSigner{sig}
 	return
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-jose/go-jose/v4
 
-go 1.24.0
+go 1.25.0


### PR DESCRIPTION
This allows users to use `crypto.Signers` that only usefully implement [`SignMessage`](https://pkg.go.dev/crypto#MessageSigner) which opens up integrations with opinionated remote signing APIs that don't support pre-hashing.

[`crypto.SignMessage`](https://pkg.go.dev/crypto#SignMessage) has been available since 1.25.0, which meets the "supports at least the current and previous Golang release" promise.