### PR TITLE
Test on Go 1.26 and 1.27

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,9 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.25.x"
           - "1.26.x"
-          - "1.27.0-rc.1"
+          - "1.27.x"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         GO_VERSION:
           # We only need to test vulns on one version
-          - "1.26.x"
+          - "1.27.x"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Go 1.27 has been released.
Switch to testing on 1.26 and 1.27.