### PR TITLE
Reject typed nil at Verify time

### DIFF
--- a/signing.go
+++ b/signing.go
@@ -130,6 +130,8 @@ type payloadVerifier interface {
 	verifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error
 }
 
+var errInvalidVerificationKey = errors.New("go-jose/go-jose: invalid verification key")
+
 type genericSigner struct {
 	recipients   []recipientSigInfo
 	nonceSource  NonceSource
@@ -188,14 +190,23 @@ func NewMultiSigner(sigs []SigningKey, opts *SignerOptions) (Signer, error) {
 func newVerifier(verificationKey interface{}) (payloadVerifier, error) {
 	switch verificationKey := verificationKey.(type) {
 	case ed25519.PublicKey:
+		if len(verificationKey) == 0 {
+			return nil, errInvalidVerificationKey
+		}
 		return &edEncrypterVerifier{
 			publicKey: verificationKey,
 		}, nil
 	case *rsa.PublicKey:
+		if verificationKey == nil {
+			return nil, errInvalidVerificationKey
+		}
 		return &rsaEncrypterVerifier{
 			publicKey: verificationKey,
 		}, nil
 	case *ecdsa.PublicKey:
+		if verificationKey == nil {
+			return nil, errInvalidVerificationKey
+		}
 		return &ecEncrypterVerifier{
 			publicKey: verificationKey,
 		}, nil
@@ -206,6 +217,9 @@ func newVerifier(verificationKey interface{}) (payloadVerifier, error) {
 	case JSONWebKey:
 		return newVerifier(verificationKey.Key)
 	case *JSONWebKey:
+		if verificationKey == nil {
+			return nil, errInvalidVerificationKey
+		}
 		return newVerifier(verificationKey.Key)
 	case OpaqueVerifier:
 		return &opaqueVerifier{verifier: verificationKey}, nil

--- a/signing_test.go
+++ b/signing_test.go
@@ -19,8 +19,10 @@ package jose
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"fmt"
 	"io"
 	"reflect"
@@ -230,6 +232,37 @@ func TestJWSInvalidKey(t *testing.T) {
 	_, err = obj.Verify("")
 	if err == nil {
 		t.Error("verification should fail with incorrect key")
+	}
+}
+
+func TestJWSNilVerificationKey(t *testing.T) {
+	tests := []struct {
+		name            string
+		algorithm       SignatureAlgorithm
+		verificationKey interface{}
+	}{
+		{name: "Ed25519", algorithm: EdDSA, verificationKey: ed25519.PublicKey(nil)},
+		{name: "ECDSA", algorithm: ES256, verificationKey: (*ecdsa.PublicKey)(nil)},
+		{name: "RSA", algorithm: RS256, verificationKey: (*rsa.PublicKey)(nil)},
+		{name: "JWK", algorithm: RS256, verificationKey: (*JSONWebKey)(nil)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			signingKey, _ := GenerateSigningTestKey(test.algorithm)
+			signer, err := NewSigner(SigningKey{Algorithm: test.algorithm, Key: signingKey}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			obj, err := signer.Sign([]byte("payload"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := obj.Verify(test.verificationKey); err != errInvalidVerificationKey {
+				t.Fatalf("Verify() error = %v, want %v", err, errInvalidVerificationKey)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Typed-nil public keys satisfy `newVerifier`'s type switch and reach the cryptographic verifier. Ed25519, ECDSA, and RSA then panic instead of returning an error. A nil `*JSONWebKey` also panics when it is dereferenced during verifier construction.

## Changes

- Reject nil Ed25519, ECDSA, RSA, and JWK verification keys before constructing a verifier.
- Return a consistent `invalid verification key` error for these inputs.
- Add table-driven JWS verification coverage for every affected key form.

## User impact

Applications that accidentally pass a typed-nil verification key now receive a normal error instead of crashing the process.

## Verification

- `go build ./...` — passed
- `go test ./... -count=1` — passed
- `go test . -run '^(TestJWSNilVerificationKey|TestJWSInvalidKey)$' -count=1` — passed
- `go vet .` — passed
- `gofmt -l .` — clean
- `git diff --check` — passed

Repository-wide `go vet ./...` additionally reports the existing intentionally malformed struct-tag fixtures in `json/decode_test.go` and `json/tagkey_test.go`; the changed package is clean.

Fixes #283