### PR TITLE
Reject unprotected b64 and crit params missing from protected header

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -364,8 +364,21 @@ func (parsed rawHeader) checkNoCritical() error {
 	return nil
 }
 
+// checkNoB64 verifies there is no "b64" header parameter present.
+// RFC 7797 section 3 requires "b64" to occur only in the JWS Protected Header.
+func (parsed rawHeader) checkNoB64() error {
+	if _, ok := parsed[headerB64]; ok {
+		return ErrUnsupportedCriticalHeader
+	}
+
+	return nil
+}
+
 // checkSupportedCritical verifies there are no unsupported critical headers.
-// Supported headers are passed in as a set: map of names to empty structs
+// Supported headers are passed in as a set: map of names to empty structs.
+// Each listed name must also occur in this same header; RFC 7515 section 4.1.11
+// forbids crit entries that do not name a Header Parameter in the JOSE Header,
+// and RFC 7797 requires "b64" itself to be integrity protected.
 func (parsed rawHeader) checkSupportedCritical(supported map[string]struct{}) error {
 	crit, err := parsed.getCritical()
 	if err != nil {
@@ -374,6 +387,9 @@ func (parsed rawHeader) checkSupportedCritical(supported map[string]struct{}) er
 
 	for _, name := range crit {
 		if _, ok := supported[name]; !ok {
+			return ErrUnsupportedCriticalHeader
+		}
+		if v, ok := parsed[HeaderKey(name)]; !ok || v == nil {
 			return ErrUnsupportedCriticalHeader
 		}
 	}

--- a/shared_test.go
+++ b/shared_test.go
@@ -36,3 +36,39 @@ func TestHeaderNotEqual(t *testing.T) {
 		t.Fatalf("header1 and header2 are equal, expected not equal")
 	}
 }
+
+func TestCheckSupportedCriticalRequiresListedParam(t *testing.T) {
+	supported := map[string]struct{}{headerB64: {}}
+
+	missing := rawHeader{}
+	if err := missing.set(headerCritical, []string{headerB64}); err != nil {
+		t.Fatal(err)
+	}
+	if err := missing.checkSupportedCritical(supported); err == nil {
+		t.Error("checkSupportedCritical accepted crit listing b64 without b64 in the same header")
+	}
+
+	present := rawHeader{}
+	if err := present.set(headerCritical, []string{headerB64}); err != nil {
+		t.Fatal(err)
+	}
+	if err := present.set(headerB64, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := present.checkSupportedCritical(supported); err != nil {
+		t.Errorf("checkSupportedCritical rejected protected b64: %v", err)
+	}
+
+	unknown := rawHeader{}
+	if err := unknown.set(headerCritical, []string{"unknown-critical-header"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := unknown.checkSupportedCritical(supported); err == nil {
+		t.Error("checkSupportedCritical accepted unknown crit header")
+	}
+
+	empty := rawHeader{}
+	if err := empty.checkSupportedCritical(supported); err != nil {
+		t.Errorf("checkSupportedCritical rejected header without crit: %v", err)
+	}
+}

--- a/signing.go
+++ b/signing.go
@@ -425,6 +425,12 @@ func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey inter
 		if err != nil {
 			return err
 		}
+		// Per https://www.rfc-editor.org/rfc/rfc7797.html#section-3,
+		// "b64" MUST occur only within the JWS Protected Header.
+		err = signature.header.checkNoB64()
+		if err != nil {
+			return err
+		}
 	}
 
 	if signature.protected != nil {
@@ -485,6 +491,12 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 			// protected; therefore, it MUST occur only within the JWS
 			// Protected Header."
 			err := signature.header.checkNoCritical()
+			if err != nil {
+				continue
+			}
+			// Per https://www.rfc-editor.org/rfc/rfc7797.html#section-3,
+			// "b64" MUST occur only within the JWS Protected Header.
+			err = signature.header.checkNoB64()
 			if err != nil {
 				continue
 			}

--- a/signing_test.go
+++ b/signing_test.go
@@ -720,6 +720,99 @@ func TestSignerB64(t *testing.T) {
 	}
 }
 
+func TestRejectUnprotectedB64(t *testing.T) {
+	key := []byte("01234567890123456789012345678901")
+
+	verifyJSON := func(t *testing.T, serialized string) {
+		t.Helper()
+		jws, err := ParseSigned(serialized, []SignatureAlgorithm{HS256})
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if _, err := jws.Verify(key); err == nil {
+			t.Error("Verify accepted JWS")
+		}
+		if _, _, _, err := jws.VerifyMulti(key); err == nil {
+			t.Error("VerifyMulti accepted JWS")
+		}
+	}
+
+	t.Run("flattened protected crit names unprotected b64", func(t *testing.T) {
+		// protected = {"alg":"HS256","crit":["b64"]}; HMAC is over the
+		// default b64=true signing input. b64=false is only unprotected.
+		const serialized = `{"payload":"YWJj","protected":"eyJhbGciOiJIUzI1NiIsImNyaXQiOlsiYjY0Il19","header":{"b64":false},"signature":"8_HaHJcOMPyCVqAMv0VFLsmmCIK_XWWJyHTyjKAaAZI"}`
+		verifyJSON(t, serialized)
+	})
+
+	t.Run("general protected crit names unprotected b64", func(t *testing.T) {
+		const serialized = `{"payload":"YWJj","signatures":[{"protected":"eyJhbGciOiJIUzI1NiIsImNyaXQiOlsiYjY0Il19","header":{"b64":false},"signature":"8_HaHJcOMPyCVqAMv0VFLsmmCIK_XWWJyHTyjKAaAZI"}]}`
+		verifyJSON(t, serialized)
+	})
+
+	signer, err := NewSigner(SigningKey{Algorithm: HS256, Key: key}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := signer.Sign([]byte("abc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj.Signatures[0].header = &rawHeader{}
+	if err := obj.Signatures[0].header.set(headerB64, false); err != nil {
+		t.Fatal(err)
+	}
+	flattenedUnprotectedB64 := obj.FullSerialize()
+
+	t.Run("flattened unprotected b64 without crit", func(t *testing.T) {
+		verifyJSON(t, flattenedUnprotectedB64)
+	})
+
+	t.Run("general unprotected b64 without crit", func(t *testing.T) {
+		verifyJSON(t, flattenedToGeneralJSON(t, flattenedUnprotectedB64))
+	})
+
+	t.Run("protected b64 with crit still verifies", func(t *testing.T) {
+		opts := new(SignerOptions)
+		opts.WithBase64(false)
+		b64Signer, err := NewSigner(SigningKey{Algorithm: HS256, Key: key}, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		signed, err := b64Signer.Sign([]byte("abc"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		jws, err := ParseSigned(signed.FullSerialize(), []SignatureAlgorithm{HS256})
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if _, err := jws.Verify(key); err != nil {
+			t.Errorf("Verify rejected protected b64: %v", err)
+		}
+	})
+}
+
+func flattenedToGeneralJSON(t *testing.T, flattened string) string {
+	t.Helper()
+	var raw rawJSONWebSignature
+	if err := json.Unmarshal([]byte(flattened), &raw); err != nil {
+		t.Fatal(err)
+	}
+	raw.Signatures = []rawSignatureInfo{{
+		Protected: raw.Protected,
+		Header:    raw.Header,
+		Signature: raw.Signature,
+	}}
+	raw.Protected = nil
+	raw.Header = nil
+	raw.Signature = nil
+	out, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
 func BenchmarkParseSigned(b *testing.B) {
 	msg := `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
## Summary
Fixes #286: `Verify`/`VerifyMulti` accepted flattened and general JWS where the protected header listed `"crit":["b64"]` but `b64` existed only in the unprotected header. Signing input used the protected default `b64=true`, while merged headers exposed `b64=false`.

- Require every `crit`-listed name to be present in that same protected header (RFC 7515 §4.1.11).
- Reject unprotected `b64` on verify (RFC 7797 §3).

## Test plan
- [x] `go test ./... -count=1`
- [x] `go test ./ -count=1 -run '^(TestCheckSupportedCriticalRequiresListedParam|TestRejectUnprotectedB64|TestSignerB64|TestInvalidJWS)$'`
- [x] Issue #286 fixture rejected; protected `b64`+`crit` still verifies