### PR TITLE
cipher/cbc_hmac: don't panic on invalid key

### DIFF
--- a/cipher/cbc_hmac.go
+++ b/cipher/cbc_hmac.go
@@ -51,6 +51,8 @@ func NewCBCHMAC(key []byte, newBlockCipher func([]byte) (cipher.Block, error)) (
 		hash = sha512.New384
 	case 32:
 		hash = sha512.New
+	default:
+		return nil, errors.New("go-jose/go-jose: invalid key size for CBC-HMAC")
 	}
 
 	return &cbcAEAD{

--- a/cipher/cbc_hmac_test.go
+++ b/cipher/cbc_hmac_test.go
@@ -259,10 +259,13 @@ func TestPadding(t *testing.T) {
 }
 
 func TestInvalidKey(t *testing.T) {
-	key := make([]byte, 30)
-	_, err := NewCBCHMAC(key, aes.NewCipher)
-	if err == nil {
-		t.Error("should not be able to instantiate CBC-HMAC with invalid key")
+	// These key sizes product an invalid hash size (key size / 2)
+	for _, n := range []int{31, 47, 63} {
+		key := make([]byte, n)
+		_, err := NewCBCHMAC(key, aes.NewCipher)
+		if err == nil {
+			t.Error("should not be able to instantiate CBC-HMAC with invalid key")
+		}
 	}
 }
 


### PR DESCRIPTION
Invalid key sizes for the hash would leave `hash func() hash.Hash` nil, leading to a panic when it is called later.