### PR TITLE
Check alg against pubkey curve during verify.

### DIFF
--- a/asymmetric.go
+++ b/asymmetric.go
@@ -21,6 +21,7 @@ import (
 	"crypto/aes"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -571,12 +572,21 @@ func (ctx ecEncrypterVerifier) verifyPayload(payload []byte, signature []byte, a
 	case ES256:
 		keySize = 32
 		hash = crypto.SHA256
+		if ctx.publicKey.Curve != elliptic.P256() {
+			return fmt.Errorf("go-jose/go-jose: signature uses different algorithm than public key")
+		}
 	case ES384:
 		keySize = 48
 		hash = crypto.SHA384
+		if ctx.publicKey.Curve != elliptic.P384() {
+			return fmt.Errorf("go-jose/go-jose: signature uses different algorithm than public key")
+		}
 	case ES512:
 		keySize = 66
 		hash = crypto.SHA512
+		if ctx.publicKey.Curve != elliptic.P521() {
+			return fmt.Errorf("go-jose/go-jose: signature uses different algorithm than public key")
+		}
 	default:
 		return ErrUnsupportedAlgorithm
 	}

--- a/asymmetric_test.go
+++ b/asymmetric_test.go
@@ -21,10 +21,13 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha512"
 	"errors"
-	"github.com/go-jose/go-jose/v4/json"
 	"io"
+	"strings"
 	"testing"
+
+	"github.com/go-jose/go-jose/v4/json"
 )
 
 func TestEd25519(t *testing.T) {
@@ -365,6 +368,54 @@ func TestInvalidEllipticCurve(t *testing.T) {
 	_, err = signer521.signPayload([]byte{}, ES384)
 	if err == nil {
 		t.Error("should not generate ES384 signature with P-521 key")
+	}
+}
+
+func TestInvalidEllipticCurveVerify(t *testing.T) {
+	payload := []byte("payload")
+
+	// Mixed signature: we're signing with P-256, but the hash is SHA-384. This
+	// allows us to trigger the "mismatched curve" code instead of the "mismatched hash"
+	// code when we try to verify using the JOSE alg ES384.
+	hash384 := sha512.Sum384(payload)
+	r, s, err := ecdsa.Sign(rand.Reader, ecTestKey256, hash384[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make a fake ES384 signature by taking the r and s from the P-256 signature
+	// and padding them out with zeroes.
+	newSignature := make([]byte, 96)
+	// FillBytes will zero-extend the 32-byte `r` and `s` values to fill the space available.
+	r.FillBytes(newSignature[:48])
+	s.FillBytes(newSignature[48:])
+
+	verifier256 := ecEncrypterVerifier{publicKey: &ecTestKey256.PublicKey}
+	err = verifier256.verifyPayload(payload, newSignature, ES384)
+	if err == nil || !strings.Contains(err.Error(), "different algorithm") {
+		t.Fatalf("verifying payload: expected error containing 'different algorithm', got %v", err)
+	}
+
+	// Mixed signature: we're signing with P-384, but the hash is SHA-512. This
+	// allows us to trigger the "mismatched curve" code instead of the "mismatched hash"
+	// code when we try to verify using the JOSE alg ES512.
+	hash512 := sha512.Sum512(payload)
+	r, s, err = ecdsa.Sign(rand.Reader, ecTestKey384, hash512[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make a fake ES512 signature by taking the r and s from the P-384 signature
+	// and padding them out with zeroes.
+	newSignature = make([]byte, 132)
+	// FillBytes will zero-extend the 48-byte `r` and `s` values to fill the space available.
+	r.FillBytes(newSignature[:66])
+	s.FillBytes(newSignature[66:])
+
+	verifier384 := ecEncrypterVerifier{publicKey: &ecTestKey384.PublicKey}
+	err = verifier384.verifyPayload(payload, newSignature, ES512)
+	if err == nil || !strings.Contains(err.Error(), "different algorithm") {
+		t.Fatalf("verifying payload: expected error containing 'different algorithm', got %v", err)
 	}
 }
 


### PR DESCRIPTION
Otherwise it's possible to craft a JWS with a (modified) P-256 signature that verifies against the corresponding P-256 public key, even though the JWS has `"alg": "ES384"`.

This issue was found by Joshua Rogers of AISLE Research and @akshithg of Trail of Bits. Thanks!

Supersedes #268